### PR TITLE
feat: Wanted page lists status=wanted books

### DIFF
--- a/web/src/app/(dashboard)/layout.tsx
+++ b/web/src/app/(dashboard)/layout.tsx
@@ -32,7 +32,8 @@ export default function DashboardLayout({
         <Sidebar />
         <main className="main">
           {!pathname.startsWith("/books") &&
-            !pathname.startsWith("/queue") && (
+            !pathname.startsWith("/queue") &&
+            !pathname.startsWith("/wanted") && (
               <Topbar title={pathnameToTitle(pathname)} />
             )}
           {children}

--- a/web/src/app/(dashboard)/wanted/page.tsx
+++ b/web/src/app/(dashboard)/wanted/page.tsx
@@ -1,7 +1,15 @@
-export default function WantedPage() {
+import { Suspense } from "react";
+import { WantedPageClient } from "@/components/wanted/wanted-page-client";
+
+export default async function WantedPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  await searchParams;
   return (
-    <div className="flex h-full items-center justify-center">
-      <p className="text-text-3 text-sm font-mono">Wanted — coming in v0.1.x</p>
-    </div>
+    <Suspense fallback={null}>
+      <WantedPageClient />
+    </Suspense>
   );
 }

--- a/web/src/components/books/books-grid.tsx
+++ b/web/src/components/books/books-grid.tsx
@@ -4,11 +4,17 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Cover } from "@/components/cover";
 import { StatusPill } from "@/components/status-pill";
 import { useFilteredBooks } from "@/lib/hooks/use-filtered-books";
+import type { BookStatus } from "@/lib/types";
 
-export function BooksGrid() {
+interface BooksGridProps {
+  basePath?: string;
+  lockedApiStatus?: BookStatus;
+}
+
+export function BooksGrid({ basePath = "/books", lockedApiStatus }: BooksGridProps = {}) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { filteredBooks, selectedId } = useFilteredBooks();
+  const { filteredBooks, selectedId } = useFilteredBooks({ lockedApiStatus });
 
   function handleSelect(id: string) {
     const params = new URLSearchParams(searchParams.toString());
@@ -17,7 +23,7 @@ export function BooksGrid() {
     } else {
       params.set("selected", id);
     }
-    router.push(`/books?${params.toString()}`);
+    router.push(`${basePath}?${params.toString()}`);
   }
 
   return (

--- a/web/src/components/books/books-table.tsx
+++ b/web/src/components/books/books-table.tsx
@@ -5,6 +5,7 @@ import { Cover } from "@/components/cover";
 import { StatusPill } from "@/components/status-pill";
 import { Icon } from "@/components/icon";
 import { useFilteredBooks, fmtDate } from "@/lib/hooks/use-filtered-books";
+import type { BookStatus } from "@/lib/types";
 
 const COLS = [
   { id: "title", label: "Title", w: "minmax(260px, 2.4fr)", sortable: true },
@@ -18,10 +19,15 @@ const COLS = [
 const GRID_COLS =
   "40px " + COLS.map((c) => c.w).join(" ") + " 36px";
 
-export function BooksTable() {
+interface BooksTableProps {
+  basePath?: string;
+  lockedApiStatus?: BookStatus;
+}
+
+export function BooksTable({ basePath = "/books", lockedApiStatus }: BooksTableProps = {}) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { filteredBooks, selectedId, sort } = useFilteredBooks();
+  const { filteredBooks, selectedId, sort } = useFilteredBooks({ lockedApiStatus });
 
   function handleSort(colId: string) {
     const params = new URLSearchParams(searchParams.toString());
@@ -31,14 +37,14 @@ export function BooksTable() {
       params.set("sort", colId);
       params.set("dir", "asc");
     }
-    router.push(`/books?${params.toString()}`);
+    router.push(`${basePath}?${params.toString()}`);
   }
 
   function handleSelect(id: string) {
     const params = new URLSearchParams(searchParams.toString());
     if (selectedId === id) params.delete("selected");
     else params.set("selected", id);
-    router.push(`/books?${params.toString()}`);
+    router.push(`${basePath}?${params.toString()}`);
   }
 
   function handleRowKey(e: React.KeyboardEvent, id: string) {

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -43,13 +43,14 @@ export function Sidebar() {
   const activeId = pathnameToId(pathname);
 
   const { data: booksData } = useQuery(bookQueries.list({ limit: 1 }));
+  const { data: wantedData } = useQuery(bookQueries.list({ status: "wanted", limit: 1 }));
   const { data: queueData } = useQuery(queueQueries.list());
   const { data: systemData } = useQuery(systemQueries.status());
 
   const booksCount = USE_MOCK ? MOCK_BOOK_COUNT : (booksData?.total ?? "—");
   const queueCount =
     queueData?.filter((i) => i.state === "downloading").length ?? "—";
-  const wantedCount = USE_MOCK ? MOCK_WANTED_COUNT : "—";
+  const wantedCount = USE_MOCK ? MOCK_WANTED_COUNT : (wantedData?.total ?? "—");
 
   const groups: NavGroup[] = [
     {

--- a/web/src/components/wanted/wanted-page-client.tsx
+++ b/web/src/components/wanted/wanted-page-client.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useFilteredBooks } from "@/lib/hooks/use-filtered-books";
+import { WantedTopbar } from "./wanted-topbar";
+import { BooksTable } from "@/components/books/books-table";
+import { BooksGrid } from "@/components/books/books-grid";
+import { DetailPanel } from "@/components/detail-panel";
+
+export function WantedPageClient() {
+  const { selectedBook, view, isLoading, isError, error, allBooks } =
+    useFilteredBooks({ lockedApiStatus: "wanted" });
+
+  function renderBody() {
+    if (isLoading) {
+      return (
+        <div className="empty">
+          <div className="empty-title">Loading wanted books…</div>
+        </div>
+      );
+    }
+    if (isError) {
+      const msg = error instanceof Error ? error.message : "Failed to load wanted books.";
+      return (
+        <div className="empty">
+          <div className="empty-title">Could not load wanted books.</div>
+          <div className="empty-sub">{msg}</div>
+        </div>
+      );
+    }
+    if (allBooks.length === 0) {
+      return (
+        <div className="empty">
+          <div className="empty-title">No wanted books.</div>
+          <div className="empty-sub">Books you add will appear here while they&apos;re being fetched.</div>
+        </div>
+      );
+    }
+    return view === "grid"
+      ? <BooksGrid basePath="/wanted" lockedApiStatus="wanted" />
+      : <BooksTable basePath="/wanted" lockedApiStatus="wanted" />;
+  }
+
+  return (
+    <>
+      <WantedTopbar />
+      <div className={`content${selectedBook ? " has-detail" : ""}`}>
+        {renderBody()}
+      </div>
+      {selectedBook && <DetailPanel book={selectedBook} />}
+    </>
+  );
+}

--- a/web/src/components/wanted/wanted-topbar.tsx
+++ b/web/src/components/wanted/wanted-topbar.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { Icon } from "@/components/icon";
+import { useFilteredBooks } from "@/lib/hooks/use-filtered-books";
+
+export function WantedTopbar() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { allBooks, view } = useFilteredBooks({ lockedApiStatus: "wanted" });
+
+  function setParam(key: string, value: string | undefined) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value != null) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    router.push(`/wanted?${params.toString()}`);
+  }
+
+  return (
+    <div className="topbar">
+      <div className="topbar-row topbar-row-1">
+        <div className="search">
+          <Icon name="search" size={15} />
+          <input type="text" placeholder="Search title, author, ISBN…" />
+          <span className="kbd-hint">
+            <span className="kbd">⌘</span>
+            <span className="kbd">K</span>
+          </span>
+        </div>
+        <div className="topbar-spacer" />
+        <button className="icon-btn" title="Refresh library">
+          <Icon name="refresh" size={15} />
+        </button>
+        <button className="icon-btn" title="Notifications">
+          <Icon name="bell" size={15} />
+          <span className="bell-dot" />
+        </button>
+        <div className="user-chip" title="admin">
+          O
+        </div>
+      </div>
+
+      <div className="topbar-row">
+        <div className="page-title">
+          <h1>Wanted</h1>
+          <span className="page-count">
+            <span className="count-num">{allBooks.length}</span>
+            <span className="count-of">books</span>
+          </span>
+        </div>
+
+        <div className="topbar-spacer" />
+
+        <div className="view-toggle" role="tablist" aria-label="View">
+          <button
+            role="tab"
+            aria-selected={view === "table"}
+            className={view === "table" ? "is-active" : ""}
+            onClick={() => setParam("view", undefined)}
+          >
+            <Icon name="table" size={14} />
+            <span>Table</span>
+          </button>
+          <button
+            role="tab"
+            aria-selected={view === "grid"}
+            className={view === "grid" ? "is-active" : ""}
+            onClick={() => setParam("view", "grid")}
+          >
+            <Icon name="grid" size={14} />
+            <span>Covers</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/hooks/use-filtered-books.ts
+++ b/web/src/lib/hooks/use-filtered-books.ts
@@ -4,8 +4,12 @@ import { useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { bookQueries } from "@/lib/queries";
-import type { BookListItem } from "@/lib/types";
+import type { BookListItem, BookStatus } from "@/lib/types";
 import { slugify } from "@/lib/utils";
+
+interface UseFilteredBooksOptions {
+  lockedApiStatus?: BookStatus;
+}
 
 export type BookView = "table" | "grid";
 export type SortCol = "title" | "author" | "status" | "added";
@@ -37,7 +41,8 @@ export function fmtDate(s: string | undefined | null): string {
   });
 }
 
-export function useFilteredBooks() {
+export function useFilteredBooks(opts: UseFilteredBooksOptions = {}) {
+  const { lockedApiStatus } = opts;
   const searchParams = useSearchParams();
 
   const selectedId = searchParams.get("selected") ?? undefined;
@@ -59,12 +64,14 @@ export function useFilteredBooks() {
   const authorFilter = searchParams.get("author") ?? undefined;
   const seriesFilter = searchParams.get("series") ?? undefined;
 
-  const { data, isLoading, isError, error } = useQuery(bookQueries.list());
+  const { data, isLoading, isError, error } = useQuery(
+    bookQueries.list(lockedApiStatus ? { status: lockedApiStatus } : undefined),
+  );
 
   const filteredBooks = useMemo<DisplayBook[]>(() => {
     let books: DisplayBook[] = [...((data?.items ?? []) as DisplayBook[])];
 
-    if (statusFilter) {
+    if (statusFilter && !lockedApiStatus) {
       books = books.filter((b) => b.display_status === statusFilter);
     }
     if (authorFilter) {
@@ -105,7 +112,7 @@ export function useFilteredBooks() {
     });
 
     return books;
-  }, [data, statusFilter, authorFilter, seriesFilter, sortCol, sortDir]);
+  }, [data, statusFilter, lockedApiStatus, authorFilter, seriesFilter, sortCol, sortDir]);
 
   const selectedBook =
     selectedId != null


### PR DESCRIPTION
Wires the Wanted sidebar entry to a real list of `status="wanted"` books. Reuses the parameterized `useFilteredBooks` and `BooksTable`/`BooksGrid` from W.2.

## Commits in this PR

- **W.1** — Sidebar Wanted count uses `bookQueries.list({ status: "wanted", limit: 1 })`
- **W.2** — Parameterize `useFilteredBooks` (`lockedApiStatus`) and `BooksTable`/`BooksGrid` (`basePath`, `lockedApiStatus`) for safe reuse
- **W.3** — Wanted page renders `WantedTopbar` + reused `BooksTable`/`BooksGrid` + `DetailPanel`. Excludes `/wanted` from the layout-level generic `<Topbar>` to avoid double-render.

## Manual test

- Sidebar Wanted count matches the page count
- Add Book modal updates both Books and Wanted counts via cache invalidation
- View toggle (Table / Covers) works on `/wanted`
- Detail panel opens, URL is `/wanted?selected=...`
- `/books` and other dashboard routes unaffected (regression check)

## Out of scope

- "Search now" / Prowlarr trigger button per row (next branch)
- Manual status transitions (Wanted → Monitored, etc.)