### PR TITLE
feat: ProwlarrClient backend integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,8 @@ LIBRARR_CLOUD_URL=https://api.librarr.com/v1
 LIBRARR_CLOUD_API_KEY=
 # Open Library (default is the public API)
 OPENLIBRARY_BASE_URL=https://openlibrary.org
+# Prowlarr indexer manager
+PROWLARR_URL=http://localhost:9696
+PROWLARR_API_KEY=
 # CORS: JSON array of allowed origins (defaults cover local dev frontend ports 5100 and 3000)
 # CORS_ALLOW_ORIGINS=["http://localhost:5100","http://localhost:3000"]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
     librarr_cloud_api_key: str = ""
     # Open Library
     openlibrary_base_url: str = "https://openlibrary.org"
+    # Prowlarr indexer manager
+    prowlarr_url: str = "http://localhost:9696"
+    prowlarr_api_key: str = ""
     # HTTP timeouts (seconds)
     http_timeout_connect: float = 5.0
     http_timeout_read: float = 10.0

--- a/app/core/deps.py
+++ b/app/core/deps.py
@@ -7,6 +7,7 @@ import httpx
 from app.core.config import settings
 from app.integrations.librarr_cloud.client import CloudClient
 from app.integrations.openlibrary.client import OpenLibraryClient
+from app.integrations.prowlarr.client import ProwlarrClient
 from app.services.metadata import MetadataService
 
 
@@ -34,3 +35,19 @@ async def get_metadata_service() -> AsyncGenerator[MetadataService]:
             ol_client=OpenLibraryClient(ol_http),
             cloud_client=CloudClient(cloud_http, api_key=settings.librarr_cloud_api_key),
         )
+
+
+async def get_prowlarr_client() -> AsyncGenerator[ProwlarrClient]:
+    """Async generator dependency: yields ProwlarrClient with a properly closed httpx client.
+
+    Per-request client is intentional for v0.1 simplicity; connection pooling
+    becomes relevant at >10 req/s. See docs/FOLLOWUPS.md.
+    """
+    async with httpx.AsyncClient(
+        base_url=settings.prowlarr_url,
+        timeout=httpx.Timeout(
+            settings.http_timeout_read,
+            connect=settings.http_timeout_connect,
+        ),
+    ) as http:
+        yield ProwlarrClient(http, api_key=settings.prowlarr_api_key)

--- a/app/integrations/exceptions.py
+++ b/app/integrations/exceptions.py
@@ -63,3 +63,35 @@ class CloudRequestError(CloudClientError):
     def __init__(self, status_code: int, message: str = "") -> None:
         self.status_code = status_code
         super().__init__(f"Cloud {status_code}: {message}")
+
+
+class ProwlarrError(IntegrationError):
+    """Base for Prowlarr errors."""
+
+
+class ProwlarrAuthError(ProwlarrError):
+    """401 from Prowlarr — invalid or missing API key."""
+
+
+class ProwlarrNotFoundError(ProwlarrError):
+    """404 from Prowlarr."""
+
+
+class ProwlarrRateLimitError(ProwlarrError):
+    """429 from Prowlarr. Respect Retry-After if present."""
+
+    def __init__(self, retry_after: int | None = None) -> None:
+        self.retry_after = retry_after
+        super().__init__(f"Prowlarr rate limited, retry_after={retry_after}")
+
+
+class ProwlarrServerError(ProwlarrError):
+    """5xx from Prowlarr."""
+
+    def __init__(self, status_code: int, message: str = "") -> None:
+        self.status_code = status_code
+        super().__init__(f"Prowlarr {status_code}: {message}")
+
+
+class ProwlarrTimeoutError(ProwlarrError):
+    """Timeout connecting to or reading from Prowlarr."""

--- a/app/integrations/prowlarr/client.py
+++ b/app/integrations/prowlarr/client.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import httpx
+import structlog
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    wait_random,
+)
+
+from app.integrations.exceptions import (
+    ProwlarrAuthError,
+    ProwlarrError,
+    ProwlarrNotFoundError,
+    ProwlarrRateLimitError,
+    ProwlarrServerError,
+    ProwlarrTimeoutError,
+)
+from app.integrations.prowlarr.schemas import (
+    ProwlarrSearchResultRaw,
+    ProwlarrSystemStatusRaw,
+)
+from app.schemas.prowlarr import ProwlarrHealth, ProwlarrRelease
+
+logger = structlog.get_logger(__name__)
+
+_SEARCH_LIMIT_DEFAULT = 25
+
+_RETRYABLE = (ProwlarrRateLimitError, ProwlarrServerError, ProwlarrTimeoutError)
+
+
+class ProwlarrClient:
+    """Async client for the Prowlarr indexer manager API."""
+
+    def __init__(self, http: httpx.AsyncClient, api_key: str) -> None:
+        self._http = http
+        self._http.headers["X-Api-Key"] = api_key
+        self._http.event_hooks["response"].append(self._log_response)
+
+    async def _log_response(self, response: httpx.Response) -> None:
+        try:
+            elapsed_ms = round(response.elapsed.total_seconds() * 1000)
+        except RuntimeError:
+            elapsed_ms = None
+
+        logger.info(
+            "prowlarr_response",
+            url=str(response.url),
+            status_code=response.status_code,
+            duration_ms=elapsed_ms,
+        )
+
+    def _raise_for_status(self, response: httpx.Response) -> None:
+        if response.status_code == 401:
+            raise ProwlarrAuthError("Prowlarr: invalid or missing API key")
+        if response.status_code == 404:
+            raise ProwlarrNotFoundError(f"Prowlarr: not found: {response.url}")
+        if response.status_code == 429:
+            retry_after_raw = response.headers.get("Retry-After")
+            retry_after: int | None = (
+                int(retry_after_raw) if retry_after_raw and retry_after_raw.isdigit() else None
+            )
+            raise ProwlarrRateLimitError(retry_after=retry_after)
+        if response.status_code >= 500:
+            raise ProwlarrServerError(status_code=response.status_code, message=response.text[:200])
+        if response.status_code >= 400:
+            raise ProwlarrError(f"{response.status_code}: {response.text[:200]}")
+
+    @retry(
+        retry=retry_if_exception_type(_RETRYABLE),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=4) + wait_random(0, 0.5),
+        reraise=True,
+    )
+    async def search(self, query: str, limit: int = _SEARCH_LIMIT_DEFAULT) -> list[ProwlarrRelease]:
+        """Search all configured Prowlarr indexers and return normalized releases."""
+        url = "/api/v1/search"
+        try:
+            response = await self._http.get(
+                url,
+                params={"query": query, "type": "search", "limit": limit},
+            )
+        except httpx.TimeoutException as exc:
+            logger.warning("prowlarr_timeout", url=url, error=str(exc))
+            raise ProwlarrTimeoutError(str(exc)) from exc
+
+        self._raise_for_status(response)
+
+        raws = [ProwlarrSearchResultRaw.model_validate(item) for item in response.json()]
+        return [
+            ProwlarrRelease(
+                guid=r.guid,
+                title=r.title,
+                indexer_name=r.indexer,
+                size_bytes=r.size,
+                publish_date=r.publish_date,
+                download_url=r.download_url,
+                info_url=r.info_url,
+                seeders=r.seeders,
+                leechers=r.leechers,
+                protocol=r.protocol,  # type: ignore[arg-type]  # Literal cast at boundary
+            )
+            for r in raws
+        ]
+
+    @retry(
+        retry=retry_if_exception_type(_RETRYABLE),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=4) + wait_random(0, 0.5),
+        reraise=True,
+    )
+    async def health(self) -> ProwlarrHealth:
+        """Fetch Prowlarr system status. Used for test-connection and health checks."""
+        url = "/api/v1/system/status"
+        try:
+            response = await self._http.get(url)
+        except httpx.TimeoutException as exc:
+            logger.warning("prowlarr_timeout", url=url, error=str(exc))
+            raise ProwlarrTimeoutError(str(exc)) from exc
+
+        self._raise_for_status(response)
+
+        raw = ProwlarrSystemStatusRaw.model_validate(response.json())
+        return ProwlarrHealth(version=raw.version, app_name=raw.app_name)

--- a/app/integrations/prowlarr/schemas.py
+++ b/app/integrations/prowlarr/schemas.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProwlarrSearchResultRaw(BaseModel):
+    """Raw release object from GET /api/v1/search."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    guid: str
+    title: str
+    indexer_id: int = Field(alias="indexerId")
+    indexer: str
+    size: int
+    publish_date: datetime = Field(alias="publishDate")
+    download_url: str = Field(alias="downloadUrl")
+    info_url: str | None = Field(default=None, alias="infoUrl")
+    seeders: int | None = None
+    leechers: int | None = None
+    protocol: str  # "torrent" | "usenet"
+
+
+class ProwlarrSystemStatusRaw(BaseModel):
+    """Raw response from GET /api/v1/system/status."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    version: str
+    app_name: str = Field(alias="appName")

--- a/app/schemas/prowlarr.py
+++ b/app/schemas/prowlarr.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ProwlarrRelease(BaseModel):
+    """Normalized release returned by ProwlarrClient.search()."""
+
+    guid: str
+    title: str
+    indexer_name: str
+    size_bytes: int
+    publish_date: datetime
+    download_url: str
+    info_url: str | None
+    seeders: int | None
+    leechers: int | None
+    protocol: Literal["torrent", "usenet"]
+
+
+class ProwlarrHealth(BaseModel):
+    """Normalized response from ProwlarrClient.health()."""
+
+    version: str
+    app_name: str

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -57,6 +57,17 @@ Re-enabling requires:
 
 Do not re-enable until both the picker UI and status taxonomy are settled.
 
+## Integration credentials storage
+
+Prowlarr (and future qBittorrent / Calibre) credentials live in env vars for v0.1. The `IntegrationConfig` DB model + Fernet encryption exist in the schema but have no API endpoints yet. Before users configure multiple indexers / download clients via the UI, this needs:
+
+- GET/POST/PATCH/DELETE `/api/v1/settings/{indexer,download-client}`
+- Fernet encryption wired on config blob read/write
+- Test-connection endpoint per integration type
+- Settings page UI in the frontend
+
+Until then, librarr supports exactly one Prowlarr instance, configured via `PROWLARR_URL` + `PROWLARR_API_KEY` env vars.
+
 ## Frontend integration milestones
 
 - **`web/src/components/sidebar-empty.tsx`** — Component exists from design source port but currently unimported. Will be wired during the first-launch flow port (v0.1.x). Do not delete; intentionally pending.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import AsyncGenerator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 
@@ -12,7 +12,7 @@ from httpx import ASGITransport
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.db import get_db
-from app.core.deps import get_metadata_service
+from app.core.deps import get_metadata_service, get_prowlarr_client
 from app.main import app
 
 # Import all models so Base.metadata is fully populated before create_all
@@ -29,6 +29,7 @@ from app.models.quality_profile import QualityProfile  # noqa: F401
 from app.models.series import Series  # noqa: F401
 from app.models.setting import Setting  # noqa: F401
 from app.schemas.metadata import AuthorStub, BookMetadata, EditionMetadata
+from app.schemas.prowlarr import ProwlarrHealth, ProwlarrRelease
 
 # ---------------------------------------------------------------------------
 # Default metadata helpers
@@ -112,9 +113,7 @@ class MockMetadataService:
     work_result: BookMetadata | None = None
     work_not_found: bool = False
 
-    async def search_books(
-        self, title: str, author: str | None = None
-    ) -> list[BookMetadata]:
+    async def search_books(self, title: str, author: str | None = None) -> list[BookMetadata]:
         if self.fail or self.search_not_found:
             return []
         if self.search_results is not None:
@@ -137,6 +136,36 @@ class MockMetadataService:
 
     async def lookup_author(self, ol_author_id: str) -> None:
         return None
+
+
+@dataclass
+class MockProwlarrClient:
+    """Configurable mock for ProwlarrClient in endpoint tests.
+
+    Defaults return empty results and a healthy status response.
+    Set fail to an exception instance to have methods raise instead of returning.
+    Inspect last_query / last_limit to assert on what the caller passed.
+    """
+
+    search_results: list[ProwlarrRelease] = field(default_factory=list)
+    health_response: ProwlarrHealth = field(
+        default_factory=lambda: ProwlarrHealth(version="1.0.0", app_name="Prowlarr")
+    )
+    fail: Exception | None = None
+    last_query: str | None = None
+    last_limit: int | None = None
+
+    async def search(self, query: str, limit: int = 25) -> list[ProwlarrRelease]:
+        self.last_query = query
+        self.last_limit = limit
+        if self.fail is not None:
+            raise self.fail
+        return list(self.search_results)
+
+    async def health(self) -> ProwlarrHealth:
+        if self.fail is not None:
+            raise self.fail
+        return self.health_response
 
 
 # ---------------------------------------------------------------------------
@@ -176,25 +205,31 @@ def mock_metadata_service() -> MockMetadataService:
 
 
 @pytest.fixture
+def mock_prowlarr_client() -> MockProwlarrClient:
+    return MockProwlarrClient()
+
+
+@pytest.fixture
 async def api_client(
     db_session: AsyncSession,
     mock_metadata_service: MockMetadataService,
+    mock_prowlarr_client: MockProwlarrClient,
 ) -> AsyncGenerator[httpx.AsyncClient]:
-    """AsyncClient against the full app with in-memory DB + mock metadata service."""
+    """AsyncClient against the full app: in-memory DB, mock metadata service, mock Prowlarr."""
 
     async def _override_get_db() -> AsyncGenerator[AsyncSession]:
         yield db_session
 
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_metadata_service] = lambda: mock_metadata_service
+    app.dependency_overrides[get_prowlarr_client] = lambda: mock_prowlarr_client
 
-    async with httpx.AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as c:
+    async with httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
 
     app.dependency_overrides.pop(get_db, None)
     app.dependency_overrides.pop(get_metadata_service, None)
+    app.dependency_overrides.pop(get_prowlarr_client, None)
 
 
 @pytest.fixture
@@ -217,12 +252,8 @@ async def api_client_with_real_metadata(
 
     def _make_real_service() -> MetadataService:
         transport = _NotFoundTransport()
-        ol_http = httpx.AsyncClient(
-            base_url="https://openlibrary.org", transport=transport
-        )
-        cloud_http = httpx.AsyncClient(
-            base_url="https://api.librarr.com", transport=transport
-        )
+        ol_http = httpx.AsyncClient(base_url="https://openlibrary.org", transport=transport)
+        cloud_http = httpx.AsyncClient(base_url="https://api.librarr.com", transport=transport)
         return MetadataService(
             ol_client=OpenLibraryClient(ol_http),
             cloud_client=CloudClient(cloud_http, api_key="test-key"),
@@ -234,9 +265,7 @@ async def api_client_with_real_metadata(
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_metadata_service] = _make_real_service
 
-    async with httpx.AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as c:
+    async with httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
 
     app.dependency_overrides.pop(get_db, None)
@@ -250,9 +279,7 @@ async def api_client_with_real_metadata(
 
 @pytest.fixture
 async def client() -> AsyncGenerator[httpx.AsyncClient]:
-    async with httpx.AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as c:
+    async with httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
 
 

--- a/tests/fixtures/prowlarr/health_response.json
+++ b/tests/fixtures/prowlarr/health_response.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.20.1.4710",
+  "appName": "Prowlarr",
+  "instanceName": "Prowlarr",
+  "branch": "master",
+  "authentication": "none",
+  "sqliteVersion": "3.43.2",
+  "urlBase": "",
+  "runtimeVersion": "6.0.24",
+  "runtimeName": ".NET",
+  "startupPath": "/app/prowlarr",
+  "appData": "/config",
+  "osName": "ubuntu",
+  "osVersion": "22.04",
+  "isMonoRuntime": false,
+  "isMono": false,
+  "isLinux": true,
+  "isOsx": false,
+  "isWindows": false,
+  "isDocker": true,
+  "mode": "console",
+  "environmentName": "Production"
+}

--- a/tests/fixtures/prowlarr/search_response.json
+++ b/tests/fixtures/prowlarr/search_response.json
@@ -1,0 +1,30 @@
+[
+  {
+    "guid": "https://indexer.example/release/1234",
+    "title": "Project.Hail.Mary.epub",
+    "indexerId": 1,
+    "indexer": "MyIndexer",
+    "size": 2097152,
+    "publishDate": "2023-08-15T14:30:00Z",
+    "downloadUrl": "https://indexer.example/download/1234.torrent",
+    "infoUrl": "https://indexer.example/details/1234",
+    "seeders": 42,
+    "leechers": 5,
+    "protocol": "torrent",
+    "categories": [{"id": 7020, "name": "Books/EBook"}]
+  },
+  {
+    "guid": "nzb://usenet.example/articles/5678",
+    "title": "Andy.Weir.Project.Hail.Mary.2021.epub-NFO",
+    "indexerId": 2,
+    "indexer": "UsenetIndexer",
+    "size": 1048576,
+    "publishDate": "2023-06-01T09:00:00Z",
+    "downloadUrl": "https://usenet.example/nzb/5678.nzb",
+    "infoUrl": null,
+    "seeders": null,
+    "leechers": null,
+    "protocol": "usenet",
+    "categories": [{"id": 7020, "name": "Books/EBook"}]
+  }
+]

--- a/tests/integration/test_prowlarr_client.py
+++ b/tests/integration/test_prowlarr_client.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from app.integrations.exceptions import (
+    ProwlarrAuthError,
+    ProwlarrNotFoundError,
+    ProwlarrRateLimitError,
+    ProwlarrServerError,
+    ProwlarrTimeoutError,
+)
+from app.integrations.prowlarr.client import ProwlarrClient
+from app.schemas.prowlarr import ProwlarrHealth, ProwlarrRelease
+from tests.conftest import load_fixture
+
+
+def make_mock_transport(
+    status_code: int,
+    body: dict | list | str,
+    headers: dict[str, str] | None = None,
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        content = json.dumps(body) if isinstance(body, (dict, list)) else body
+        return httpx.Response(status_code, content=content.encode(), headers=headers or {})
+
+    return httpx.MockTransport(handler)
+
+
+def make_prowlarr_client(
+    status_code: int = 200,
+    body: dict | list | str = "",
+    headers: dict[str, str] | None = None,
+) -> ProwlarrClient:
+    http = httpx.AsyncClient(
+        transport=make_mock_transport(status_code, body, headers),
+        base_url="http://prowlarr.test",
+    )
+    return ProwlarrClient(http, api_key="test-key")
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_returns_normalized_releases() -> None:
+    fixture = load_fixture("prowlarr/search_response.json")
+    client = make_prowlarr_client(body=fixture)
+
+    releases = await client.search("project hail mary")
+
+    assert len(releases) == len(fixture)
+    assert isinstance(releases[0], ProwlarrRelease)
+    assert releases[0].indexer_name == fixture[0]["indexer"]
+    assert releases[0].size_bytes == fixture[0]["size"]
+
+
+async def test_search_passes_query_params() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(dict(request.url.params))
+        return httpx.Response(200, content=b"[]")
+
+    http = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://prowlarr.test"
+    )
+    client = ProwlarrClient(http, api_key="k")
+
+    await client.search("andy weir", limit=10)
+
+    assert captured.get("query") == "andy weir"
+    assert captured.get("type") == "search"
+    assert captured.get("limit") == "10"
+
+
+async def test_search_returns_empty_on_no_results() -> None:
+    client = make_prowlarr_client(body=[])
+
+    assert await client.search("nothing matches") == []
+
+
+async def test_search_handles_usenet_release_with_null_fields() -> None:
+    fixture = load_fixture("prowlarr/search_response.json")
+    client = make_prowlarr_client(body=fixture)
+
+    releases = await client.search("project hail mary")
+
+    usenet = releases[1]
+    assert usenet.protocol == "usenet"
+    assert usenet.seeders is None
+    assert usenet.leechers is None
+    assert usenet.info_url is None
+
+
+# ---------------------------------------------------------------------------
+# health()
+# ---------------------------------------------------------------------------
+
+
+async def test_health_returns_normalized_status() -> None:
+    fixture = load_fixture("prowlarr/health_response.json")
+    client = make_prowlarr_client(body=fixture)
+
+    health = await client.health()
+
+    assert isinstance(health, ProwlarrHealth)
+    assert health.version == fixture["version"]
+    assert health.app_name == fixture["appName"]
+
+
+# ---------------------------------------------------------------------------
+# error translation
+# ---------------------------------------------------------------------------
+
+
+async def test_401_raises_auth_error() -> None:
+    client = make_prowlarr_client(status_code=401, body={"error": "unauthorized"})
+
+    with pytest.raises(ProwlarrAuthError):
+        await client.search("q")
+
+
+async def test_404_raises_not_found() -> None:
+    client = make_prowlarr_client(status_code=404, body={"error": "not found"})
+
+    with pytest.raises(ProwlarrNotFoundError):
+        await client.search("q")
+
+
+async def test_429_raises_rate_limit_with_retry_after() -> None:
+    client = make_prowlarr_client(
+        status_code=429,
+        body={"error": "too many requests"},
+        headers={"Retry-After": "30"},
+    )
+
+    with pytest.raises(ProwlarrRateLimitError) as exc_info:
+        await client.search("q")
+
+    assert exc_info.value.retry_after == 30
+
+
+async def test_500_raises_server_error_after_retries() -> None:
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        return httpx.Response(500, content=b'{"error": "internal"}')
+
+    http = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://prowlarr.test"
+    )
+    client = ProwlarrClient(http, api_key="k")
+
+    with pytest.raises(ProwlarrServerError):
+        await client.search("q")
+
+    assert call_count == 3
+
+
+async def test_timeout_raises_timeout_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("connection timed out")
+
+    http = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://prowlarr.test"
+    )
+    client = ProwlarrClient(http, api_key="k")
+
+    with pytest.raises(ProwlarrTimeoutError):
+        await client.search("q")


### PR DESCRIPTION
Adds the Prowlarr API client to the librarr backend. Backend-only — no frontend changes, no API endpoints, no service-layer wiring. Foundation for `feat/search-trigger` (next branch) which will expose `POST /api/v1/book/{id}/search` and add a "Search now" button to the Wanted page.

## Commits

- **P.1** — Settings: `prowlarr_url`, `prowlarr_api_key` (env-var-driven for v0.1)
- **P.2** — Exception hierarchy mirroring `CloudClient`/`OL` (Auth/NotFound/RateLimit/Server/Timeout)
- **P.3** — Raw schemas (`ProwlarrSearchResultRaw`, `ProwlarrSystemStatusRaw`) + normalized domain types (`ProwlarrRelease`, `ProwlarrHealth`)
- **P.4** — `ProwlarrClient` with `search()` and `health()`. X-Api-Key header, structlog event hook, tenacity retry on rate-limit/5xx/timeout
- **P.5** — `get_prowlarr_client` async generator dep + `MockProwlarrClient` fixture wired into `api_client` test fixture
- **P.6** — 10 unit tests via `httpx.MockTransport` covering search/health happy paths, query param shape, normalization, and all five HTTP error translations

## Tests
- **74 passing** (was 64; +10 new)
- Coverage: search normalization, query param shape, empty results, health, 401/404/429/500/timeout error paths, 429 Retry-After parsing, 500 retry exhaustion (3 attempts asserted)

## Out of scope
- API endpoints exposing Prowlarr to the frontend (next branch: `feat/search-trigger`)
- IntegrationConfig DB integration / Fernet encryption / Settings UI (FOLLOWUPS)
- Retry sleep mocking for faster test runtime (FOLLOWUPS — adds ~6s to suite)

## FOLLOWUPS additions
- Integration credentials storage (env-var → DB + encryption + UI migration)