### PR TITLE
feat: manual indexer search trigger for wanted books

### DIFF
--- a/app/api/v1/book.py
+++ b/app/api/v1/book.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import uuid
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_db
-from app.core.deps import get_metadata_service
+from app.core.deps import get_metadata_service, get_prowlarr_client
+from app.integrations.exceptions import (
+    ProwlarrAuthError,
+    ProwlarrRateLimitError,
+    ProwlarrServerError,
+    ProwlarrTimeoutError,
+)
+from app.integrations.prowlarr.client import ProwlarrClient
 from app.schemas.book import (
     AddBookRequest,
     BookCreateResponse,
@@ -19,6 +26,7 @@ from app.schemas.book import (
     BookSearchResult,
 )
 from app.schemas.common import PaginatedResponse
+from app.schemas.prowlarr import ProwlarrRelease
 from app.services.book_service import BookService
 from app.services.metadata import MetadataService
 
@@ -122,3 +130,26 @@ async def delete_book(
     hard: Annotated[bool, Query()] = False,
 ) -> dict:
     return await svc.delete_book(book_id, db, hard=hard)
+
+
+@router.post("/{book_id}/search", response_model=list[ProwlarrRelease])
+async def search_book_releases(
+    book_id: uuid.UUID,
+    svc: Annotated[BookService, Depends(_book_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    prowlarr: Annotated[ProwlarrClient, Depends(get_prowlarr_client)],
+) -> list[ProwlarrRelease]:
+    try:
+        return await svc.search_releases(book_id, db, prowlarr)
+    except ProwlarrAuthError:
+        raise HTTPException(status_code=502, detail="Prowlarr authentication failed")
+    except ProwlarrTimeoutError:
+        raise HTTPException(status_code=503, detail="Prowlarr unreachable")
+    except ProwlarrServerError as exc:
+        raise HTTPException(status_code=502, detail=f"Prowlarr error: {str(exc)[:100]}")
+    except ProwlarrRateLimitError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail="Prowlarr rate limited",
+            headers={"Retry-After": str(exc.retry_after or 60)},
+        )

--- a/app/api/v1/command.py
+++ b/app/api/v1/command.py
@@ -18,7 +18,8 @@ from app.services.metadata import MetadataService
 router = APIRouter()
 logger = structlog.get_logger(__name__)
 
-_STUB_COMMANDS = {"BookSearch", "RescanLibrary"}
+# BookSearch moved to POST /api/v1/book/{book_id}/search
+_STUB_COMMANDS = {"RescanLibrary"}
 
 
 def _book_service(meta: Annotated[MetadataService, Depends(get_metadata_service)]) -> BookService:
@@ -76,7 +77,7 @@ async def run_command(
             body=request.body,
         )
 
-    known = "RefreshBook, BookSearch, RescanLibrary"
+    known = "RefreshBook, RescanLibrary"
     raise HTTPException(
         status_code=422,
         detail=f"Unknown command: {request.name!r}. Known commands: {known}",

--- a/app/integrations/prowlarr/client.py
+++ b/app/integrations/prowlarr/client.py
@@ -82,7 +82,7 @@ class ProwlarrClient:
                 url,
                 params={"query": query, "type": "search", "limit": limit},
             )
-        except httpx.TimeoutException as exc:
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
             logger.warning("prowlarr_timeout", url=url, error=str(exc))
             raise ProwlarrTimeoutError(str(exc)) from exc
 
@@ -116,7 +116,7 @@ class ProwlarrClient:
         url = "/api/v1/system/status"
         try:
             response = await self._http.get(url)
-        except httpx.TimeoutException as exc:
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
             logger.warning("prowlarr_timeout", url=url, error=str(exc))
             raise ProwlarrTimeoutError(str(exc)) from exc
 

--- a/app/services/book_service.py
+++ b/app/services/book_service.py
@@ -12,6 +12,7 @@ from app.core.exceptions import (
     BookNotFoundError,
     DuplicateBookError,
 )
+from app.integrations.prowlarr.client import ProwlarrClient
 from app.repositories.author import AuthorRepository
 from app.repositories.book import AuthorWithRole, BookRepository
 from app.repositories.edition import EditionRepository
@@ -31,6 +32,7 @@ from app.schemas.book import (
     TitleAuthorLookup,
 )
 from app.schemas.common import PaginatedResponse
+from app.schemas.prowlarr import ProwlarrRelease
 
 if TYPE_CHECKING:
     from app.models.author import Author
@@ -109,8 +111,7 @@ class BookService:
                         author_stubs = work.authors
             else:
                 warnings.append(
-                    f"No metadata found for ISBN {request.isbn}. "
-                    "Book added with minimal data."
+                    f"No metadata found for ISBN {request.isbn}. Book added with minimal data."
                 )
                 book_title = request.isbn
                 edition_data = {
@@ -120,9 +121,7 @@ class BookService:
                 }
 
         else:  # TitleAuthorLookup
-            results = await self._meta.search_books(
-                title=request.title, author=request.author
-            )
+            results = await self._meta.search_books(title=request.title, author=request.author)
             if results:
                 best = results[0]
                 book_title = best.title
@@ -137,8 +136,7 @@ class BookService:
                 metadata_status = "resolved" if best.system_confidence >= 0.7 else "partial"
             else:
                 warnings.append(
-                    "No metadata found for this title/author. "
-                    "Book added with minimal data."
+                    "No metadata found for this title/author. Book added with minimal data."
                 )
 
         # Persist within a single transaction
@@ -306,6 +304,25 @@ class BookService:
             await db.commit()
 
         return await self._build_book_detail(book, books, db)
+
+    # ------------------------------------------------------------------
+    # Search releases (Prowlarr)
+    # ------------------------------------------------------------------
+
+    async def search_releases(
+        self, book_id: uuid.UUID, db: AsyncSession, prowlarr: ProwlarrClient
+    ) -> list[ProwlarrRelease]:
+        books = BookRepository(db)
+        book = await books.get(book_id)
+        if book is None:
+            raise BookNotFoundError(str(book_id))
+
+        author_rows = await books.get_authors_for_book(book_id)
+        query = book.title
+        if author_rows:
+            query = f"{book.title} {author_rows[0].author.canonical_name}"
+
+        return await prowlarr.search(query)
 
     # ------------------------------------------------------------------
     # Author detail

--- a/tests/integration/test_book_api.py
+++ b/tests/integration/test_book_api.py
@@ -537,17 +537,12 @@ async def test_command_refresh_book_no_changes(api_client: httpx.AsyncClient) ->
     assert r_get.json()["system_confidence"] == original_conf
 
 
-async def test_command_book_search_stub(api_client: httpx.AsyncClient) -> None:
+async def test_command_book_search_unknown(api_client: httpx.AsyncClient) -> None:
     r = await api_client.post(
         "/api/v1/command",
         json={"name": "BookSearch", "body": {}},
     )
-    assert r.status_code == 201
-    body = r.json()
-    assert body["status"] == "queued"
-    assert body["name"] == "BookSearch"
-    assert body["started_at"] is None
-    assert body["ended_at"] is None
+    assert r.status_code == 422
 
 
 async def test_command_unknown(api_client: httpx.AsyncClient) -> None:

--- a/tests/integration/test_book_search.py
+++ b/tests/integration/test_book_search.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import httpx
+
+from app.integrations.exceptions import ProwlarrAuthError, ProwlarrTimeoutError
+from app.schemas.prowlarr import ProwlarrRelease
+from tests.conftest import MockProwlarrClient
+
+_TITLE_PAYLOAD = {"lookup_type": "title_author", "title": "Dune"}
+
+
+def _release(guid: str = "guid-1") -> ProwlarrRelease:
+    return ProwlarrRelease(
+        guid=guid,
+        title=f"Release {guid}",
+        indexer_name="TestIndexer",
+        size_bytes=500_000,
+        publish_date=datetime(2024, 1, 1, tzinfo=UTC),
+        download_url=f"https://fake.test/dl/{guid}",
+        info_url=None,
+        seeders=5,
+        leechers=1,
+        protocol="torrent",
+    )
+
+
+async def test_search_releases_returns_results(
+    api_client: httpx.AsyncClient,
+    mock_prowlarr_client: MockProwlarrClient,
+) -> None:
+    r_add = await api_client.post("/api/v1/book", json=_TITLE_PAYLOAD)
+    assert r_add.status_code == 201
+    book_id = r_add.json()["book"]["id"]
+
+    mock_prowlarr_client.search_results = [_release("guid-1")]
+
+    r = await api_client.post(f"/api/v1/book/{book_id}/search")
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 1
+    assert body[0]["guid"] == "guid-1"
+    assert body[0]["indexer_name"] == "TestIndexer"
+    assert body[0]["protocol"] == "torrent"
+    assert body[0]["size_bytes"] == 500_000
+
+
+async def test_search_releases_empty_results(
+    api_client: httpx.AsyncClient,
+    mock_prowlarr_client: MockProwlarrClient,
+) -> None:
+    r_add = await api_client.post("/api/v1/book", json=_TITLE_PAYLOAD)
+    assert r_add.status_code == 201
+    book_id = r_add.json()["book"]["id"]
+    # mock_prowlarr_client.search_results defaults to []
+
+    r = await api_client.post(f"/api/v1/book/{book_id}/search")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+async def test_search_releases_book_not_found(
+    api_client: httpx.AsyncClient,
+) -> None:
+    r = await api_client.post(f"/api/v1/book/{uuid.uuid4()}/search")
+    assert r.status_code == 404
+    assert r.json()["error"] == "not_found"
+
+
+async def test_search_releases_query_includes_author(
+    api_client: httpx.AsyncClient,
+    mock_prowlarr_client: MockProwlarrClient,
+) -> None:
+    # Default mock metadata: title="Dune", author="Test Author"
+    r_add = await api_client.post("/api/v1/book", json=_TITLE_PAYLOAD)
+    assert r_add.status_code == 201
+    book_id = r_add.json()["book"]["id"]
+
+    await api_client.post(f"/api/v1/book/{book_id}/search")
+
+    assert mock_prowlarr_client.last_query == "Dune Test Author"
+
+
+async def test_search_releases_query_title_only_when_no_authors(
+    api_client: httpx.AsyncClient,
+    mock_prowlarr_client: MockProwlarrClient,
+    mock_metadata_service: object,
+) -> None:
+    mock_metadata_service.search_not_found = True  # type: ignore[attr-defined]
+    r_add = await api_client.post(
+        "/api/v1/book", json={"lookup_type": "title_author", "title": "Orphan Book"}
+    )
+    assert r_add.status_code == 201
+    book_id = r_add.json()["book"]["id"]
+
+    await api_client.post(f"/api/v1/book/{book_id}/search")
+
+    assert mock_prowlarr_client.last_query == "Orphan Book"
+
+
+async def test_search_releases_prowlarr_timeout_returns_503(
+    api_client: httpx.AsyncClient,
+    mock_prowlarr_client: MockProwlarrClient,
+) -> None:
+    r_add = await api_client.post("/api/v1/book", json=_TITLE_PAYLOAD)
+    assert r_add.status_code == 201
+    book_id = r_add.json()["book"]["id"]
+
+    mock_prowlarr_client.fail = ProwlarrTimeoutError("connection timed out")
+
+    r = await api_client.post(f"/api/v1/book/{book_id}/search")
+    assert r.status_code == 503
+    assert r.json()["detail"] == "Prowlarr unreachable"
+
+
+async def test_search_releases_prowlarr_auth_error_returns_502(
+    api_client: httpx.AsyncClient,
+    mock_prowlarr_client: MockProwlarrClient,
+) -> None:
+    r_add = await api_client.post("/api/v1/book", json=_TITLE_PAYLOAD)
+    assert r_add.status_code == 201
+    book_id = r_add.json()["book"]["id"]
+
+    mock_prowlarr_client.fail = ProwlarrAuthError("invalid api key")
+
+    r = await api_client.post(f"/api/v1/book/{book_id}/search")
+    assert r.status_code == 502
+    assert r.json()["detail"] == "Prowlarr authentication failed"

--- a/tests/integration/test_prowlarr_client.py
+++ b/tests/integration/test_prowlarr_client.py
@@ -174,3 +174,18 @@ async def test_timeout_raises_timeout_error() -> None:
 
     with pytest.raises(ProwlarrTimeoutError):
         await client.search("q")
+
+
+async def test_connect_error_raises_timeout_error() -> None:
+    """httpx.ConnectError (e.g., Prowlarr not running) is translated to ProwlarrTimeoutError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    http = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://prowlarr.test"
+    )
+    client = ProwlarrClient(http, api_key="k")
+
+    with pytest.raises(ProwlarrTimeoutError):
+        await client.search("q")

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -898,6 +898,24 @@ body {
 }
 .action-spacer { flex: 1; }
 .btn-danger:hover { color: oklch(72% 0.16 25); border-color: oklch(60% 0.13 25); }
+.release-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.release-row {
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-sm);
+}
+.release-title {
+  font-size: 12px; color: var(--text-2); font-weight: 450;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  margin-bottom: 5px;
+}
+.release-meta { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.release-indexer { font-size: 11px; color: var(--text-4); }
+.release-size { font-size: 11px; color: var(--text-4); }
+.release-seeders { font-size: 11px; color: var(--text-3); }
+.releases-searching { font-size: 12px; color: var(--text-3); padding: 6px 0; }
+.releases-error { font-size: 12px; color: oklch(70% 0.16 25); padding: 6px 0; }
 
 /* ── Reduced motion ──────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {

--- a/web/src/components/detail-panel.tsx
+++ b/web/src/components/detail-panel.tsx
@@ -2,13 +2,37 @@
 
 import { useCallback, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
 import { Cover } from "@/components/cover";
 import { StatusPill } from "@/components/status-pill";
 import { Icon } from "@/components/icon";
+import { APIError } from "@/lib/api/client";
+import { booksApi } from "@/lib/api/books";
 import type { MockBook } from "@/lib/mock/books";
+import type { ProwlarrRelease } from "@/lib/types";
 
 interface DetailPanelProps {
   book: MockBook;
+}
+
+function formatBytes(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let i = 0;
+  let val = bytes;
+  while (val >= 1024 && i < units.length - 1) {
+    val /= 1024;
+    i++;
+  }
+  return i === 0 ? `${val} ${units[i]}` : `${val.toFixed(1)} ${units[i]}`;
+}
+
+function getReleaseErrorMessage(err: unknown): string {
+  if (err instanceof APIError) {
+    if (err.status === 503) return "Prowlarr unreachable. Check that the indexer service is running.";
+    if (err.status === 502) return "Prowlarr error. Check the API key and indexer config.";
+    if (err.status === 429) return "Prowlarr is rate-limited. Try again in a moment.";
+  }
+  return "Search failed. Try again.";
 }
 
 export function DetailPanel({ book }: DetailPanelProps) {
@@ -16,6 +40,10 @@ export function DetailPanel({ book }: DetailPanelProps) {
   const searchParams = useSearchParams();
 
   const isAudio = book.format === "m4b";
+
+  const searchMutation = useMutation({
+    mutationFn: (bookId: string) => booksApi.searchReleases(bookId),
+  });
 
   const handleClose = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString());
@@ -178,6 +206,38 @@ export function DetailPanel({ book }: DetailPanelProps) {
           )}
         </div>
 
+        {!searchMutation.isIdle && (
+          <div className="detail-section">
+            <div className="section-label">Available releases</div>
+            {searchMutation.isPending && (
+              <div className="releases-searching">Searching indexers…</div>
+            )}
+            {searchMutation.error && (
+              <div className="releases-error">{getReleaseErrorMessage(searchMutation.error)}</div>
+            )}
+            {searchMutation.data !== undefined && searchMutation.data.length === 0 && (
+              <div className="files-empty"><span className="dim">No releases found.</span></div>
+            )}
+            {searchMutation.data && searchMutation.data.length > 0 && (
+              <ul className="release-list">
+                {searchMutation.data.map((r: ProwlarrRelease) => (
+                  <li key={r.guid} className="release-row">
+                    <div className="release-title">{r.title}</div>
+                    <div className="release-meta">
+                      <span className="release-indexer">{r.indexer_name}</span>
+                      <span className="release-size mono">{formatBytes(r.size_bytes)}</span>
+                      <span className={`proto proto-${r.protocol}`}>{r.protocol}</span>
+                      {r.protocol === "torrent" && r.seeders != null && (
+                        <span className="release-seeders">🟢 {r.seeders}</span>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
         <div className="detail-section">
           <div className="section-label">Activity</div>
           <ol className="timeline">
@@ -193,9 +253,14 @@ export function DetailPanel({ book }: DetailPanelProps) {
       </div>
 
       <div className="detail-actions">
-        <button className="btn btn-ghost" title="Search indexers">
+        <button
+          className="btn btn-ghost"
+          title="Search indexers"
+          onClick={() => searchMutation.mutate(book.id)}
+          disabled={searchMutation.isPending}
+        >
           <Icon name="refresh" size={13} />
-          <span>Search again</span>
+          <span>{searchMutation.isPending ? "Searching…" : "Search again"}</span>
         </button>
         <button className="btn btn-ghost">
           <Icon name="edit" size={13} />

--- a/web/src/lib/api/books.ts
+++ b/web/src/lib/api/books.ts
@@ -8,6 +8,7 @@ import type {
   BookPatchRequest,
   BookSearchResponse,
   PaginatedResponse,
+  ProwlarrRelease,
 } from "@/lib/types";
 
 function buildQuery(params: Record<string, unknown>): string {
@@ -40,4 +41,8 @@ export const booksApi = {
     }),
   search: (params: { title: string; author?: string }) =>
     apiFetch<BookSearchResponse>(`/api/v1/book/search${buildQuery(params)}`),
+  searchReleases: (bookId: string) =>
+    apiFetch<ProwlarrRelease[]>(`/api/v1/book/${bookId}/search`, {
+      method: "POST",
+    }),
 };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -301,6 +301,21 @@ export interface QueueItem {
   avgSpeed?: string;
 }
 
+// ── Prowlarr ──────────────────────────────────────────────────────────────────
+
+export interface ProwlarrRelease {
+  guid: string;
+  title: string;
+  indexer_name: string;
+  size_bytes: number;
+  publish_date: string; // ISO datetime string
+  download_url: string;
+  info_url: string | null;
+  seeders: number | null;
+  leechers: number | null;
+  protocol: DownloadProtocol;
+}
+
 // ── System ────────────────────────────────────────────────────────────────────
 
 export interface SystemStatus {


### PR DESCRIPTION
Adds a manual "Search again" trigger on the book detail panel that queries Prowlarr for available releases. Result rows are display-only — no per-row download trigger yet (next branch: `feat/download-trigger`).

This completes the chain: user adds book → wanted → opens detail → clicks Search again → sees what's available across configured indexers.

## Commits

- **Backend** (4280f7b) — `POST /api/v1/book/{id}/search` endpoint, `BookService.search_releases`, removed `BookSearch` from `_STUB_COMMANDS`. 7 new integration tests.
- **Types + API** (5f8aae7) — `ProwlarrRelease` interface, `booksApi.searchReleases(bookId)` method.
- **UI** (fde61be) — `useMutation` wired to "Search again" button, "Available releases" section above Activity with loading/error/empty/results states.
- **Fix** (62c14ab) — `httpx.ConnectError` translated to `ProwlarrTimeoutError`. Without this, Prowlarr being down returned 500 instead of 503, frontend showed generic fallback instead of "Prowlarr unreachable".

## Tests

- **82 passing** (was 74; +8 new)
- Manual test confirmed: real Prowlarr connection works, empty state renders correctly, error states surface friendly copy

## Out of scope

- Per-release download trigger (next: `feat/download-trigger`)
- Multi-indexer selection / filtering
- Multi-author query construction (uses first author only — FOLLOWUPS)
- ISBN-based search
- Result caching (every click is a fresh API call by design)