### PR TITLE
feat(integrations): add qbittorrent service and api endpoints

### DIFF
--- a/app/api/v1/integrations.py
+++ b/app/api/v1/integrations.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.services.qbittorrent_service as qbt_service
+from app.core.db import get_db
+from app.schemas.qbittorrent import (
+    QBittorrentConfigIn,
+    QBittorrentConfigOut,
+    QBittorrentTestRequest,
+    QBittorrentTestResult,
+)
+
+router = APIRouter()
+
+_DB = Annotated[AsyncSession, Depends(get_db)]
+
+
+@router.get("/qbittorrent", response_model=QBittorrentConfigOut | None)
+async def get_qbittorrent(session: _DB) -> QBittorrentConfigOut | None:
+    return await qbt_service.get_config(session)
+
+
+@router.put("/qbittorrent", response_model=QBittorrentConfigOut)
+async def upsert_qbittorrent(
+    body: QBittorrentConfigIn, session: _DB
+) -> QBittorrentConfigOut:
+    return await qbt_service.upsert_config(session, body)
+
+
+@router.delete("/qbittorrent", status_code=204)
+async def delete_qbittorrent(session: _DB) -> None:
+    deleted = await qbt_service.delete_config(session)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="qBittorrent not configured")
+
+
+@router.post("/qbittorrent/test", response_model=QBittorrentTestResult)
+async def test_qbittorrent(body: QBittorrentTestRequest) -> QBittorrentTestResult:
+    return await qbt_service.test_connection(
+        body.host, body.port, body.username, body.password, body.use_https
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+from cryptography.fernet import Fernet
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_FERNET_KEY_HELP = (
+    "LIBRARR_SECRET_KEY env var is required. "
+    "Generate with: python -c "
+    "'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'"
+)
 
 
 class Settings(BaseSettings):
@@ -23,6 +31,19 @@ class Settings(BaseSettings):
     cloud_timeout_read: float = 4.5  # leaves budget for service-layer 5s fallback
     # CORS
     cors_allow_origins: list[str] = ["http://localhost:5100", "http://localhost:3000"]
+    # Encryption — required, no default
+    librarr_secret_key: str = Field(default="")
+
+    @field_validator("librarr_secret_key")
+    @classmethod
+    def validate_fernet_key(cls, v: str) -> str:
+        if not v:
+            raise ValueError(_FERNET_KEY_HELP)
+        try:
+            Fernet(v.encode())
+        except Exception:
+            raise ValueError(_FERNET_KEY_HELP)
+        return v
 
 
 settings = Settings()

--- a/app/core/crypto.py
+++ b/app/core/crypto.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from cryptography.fernet import Fernet
+
+from app.core.config import settings
+
+_fernet = Fernet(settings.librarr_secret_key.encode())
+
+
+def encrypt_config(data: dict[str, Any]) -> bytes:
+    plaintext = json.dumps(data).encode()
+    return _fernet.encrypt(plaintext)
+
+
+def decrypt_config(ciphertext: bytes) -> dict[str, Any]:
+    plaintext = _fernet.decrypt(ciphertext)
+    return json.loads(plaintext.decode())

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.api.errors import register_error_handlers
 from app.api.v1 import author as author_router
 from app.api.v1 import book as book_router
 from app.api.v1 import command as command_router
+from app.api.v1 import integrations as integrations_router
 from app.api.v1 import system
 from app.core.config import settings
 from app.core.logging import configure_logging
@@ -32,6 +33,9 @@ def create_app() -> FastAPI:
     application.include_router(book_router.router, prefix="/api/v1/book", tags=["book"])
     application.include_router(author_router.router, prefix="/api/v1/author", tags=["author"])
     application.include_router(command_router.router, prefix="/api/v1/command", tags=["command"])
+    application.include_router(
+        integrations_router.router, prefix="/api/v1/integrations", tags=["integrations"]
+    )
 
     register_error_handlers(application)
 

--- a/app/repositories/integration_config.py
+++ b/app/repositories/integration_config.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.integration_config import IntegrationConfig
+
+
+class IntegrationConfigRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._s = session
+
+    async def get_by_type(self, type_: str) -> IntegrationConfig | None:
+        stmt = select(IntegrationConfig).where(IntegrationConfig.type == type_)
+        return (await self._s.execute(stmt)).scalar_one_or_none()
+
+    async def upsert(
+        self,
+        type_: str,
+        name: str,
+        config_bytes: bytes,
+        enabled: bool,
+    ) -> IntegrationConfig:
+        now = datetime.now(tz=UTC)
+        existing = await self.get_by_type(type_)
+        if existing is not None:
+            await self._s.execute(
+                update(IntegrationConfig)
+                .where(IntegrationConfig.type == type_)
+                .values(name=name, config=config_bytes, enabled=enabled, updated_at=now)
+            )
+            await self._s.flush()
+            await self._s.refresh(existing)
+            return existing
+        row = IntegrationConfig(
+            type=type_,
+            name=name,
+            config=config_bytes,
+            enabled=enabled,
+        )
+        self._s.add(row)
+        await self._s.flush()
+        await self._s.refresh(row)
+        return row
+
+    async def delete_by_type(self, type_: str) -> bool:
+        result = await self._s.execute(
+            delete(IntegrationConfig).where(IntegrationConfig.type == type_)
+        )
+        await self._s.flush()
+        return result.rowcount > 0  # type: ignore[attr-defined]
+
+    async def update_test_result(self, type_: str, ok: bool) -> None:
+        now = datetime.now(tz=UTC)
+        await self._s.execute(
+            update(IntegrationConfig)
+            .where(IntegrationConfig.type == type_)
+            .values(last_test_at=now, last_test_ok=ok, updated_at=now)
+        )
+        await self._s.flush()

--- a/app/schemas/qbittorrent.py
+++ b/app/schemas/qbittorrent.py
@@ -1,9 +1,50 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
 
 
 class QBittorrentHealth(BaseModel):
     """qBittorrent version. Used for test-connection."""
 
     version: str
+
+
+class QBittorrentConfigIn(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    host: str = Field(min_length=1)
+    port: int = Field(ge=1, le=65535)
+    username: str = Field(min_length=1)
+    password: str = Field(min_length=1)
+    use_https: bool = False
+    enabled: bool = True
+
+
+class QBittorrentConfigOut(BaseModel):
+    id: uuid.UUID
+    name: str
+    host: str
+    port: int
+    username: str
+    use_https: bool
+    enabled: bool
+    last_test_at: datetime | None
+    last_test_ok: bool | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class QBittorrentTestRequest(BaseModel):
+    host: str
+    port: int = Field(ge=1, le=65535)
+    username: str
+    password: str
+    use_https: bool = False
+
+
+class QBittorrentTestResult(BaseModel):
+    ok: bool
+    version: str | None = None
+    error: str | None = None

--- a/app/services/qbittorrent_service.py
+++ b/app/services/qbittorrent_service.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.crypto import decrypt_config, encrypt_config
+from app.integrations.exceptions import (
+    QBittorrentAuthError,
+    QBittorrentError,
+    QBittorrentForbiddenError,
+    QBittorrentTimeoutError,
+)
+from app.integrations.qbittorrent.client import QBittorrentClient
+from app.repositories.integration_config import IntegrationConfigRepository
+from app.schemas.qbittorrent import (
+    QBittorrentConfigIn,
+    QBittorrentConfigOut,
+    QBittorrentTestResult,
+)
+
+_TYPE = "qbittorrent"
+
+
+@contextlib.asynccontextmanager
+async def _build_client(
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    use_https: bool,
+) -> AsyncGenerator[QBittorrentClient]:
+    scheme = "https" if use_https else "http"
+    base_url = f"{scheme}://{host}:{port}"
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        timeout=httpx.Timeout(
+            settings.http_timeout_read,
+            connect=settings.http_timeout_connect,
+        ),
+    ) as http:
+        yield QBittorrentClient(http, username=username, password=password)
+
+
+async def test_connection(
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    use_https: bool,
+) -> QBittorrentTestResult:
+    try:
+        async with _build_client(host, port, username, password, use_https) as client:
+            health = await client.health()
+        return QBittorrentTestResult(ok=True, version=health.version)
+    except QBittorrentAuthError:
+        return QBittorrentTestResult(ok=False, error="invalid credentials")
+    except QBittorrentForbiddenError:
+        return QBittorrentTestResult(
+            ok=False,
+            error="forbidden — check Server domains in qBittorrent Web UI settings",
+        )
+    except QBittorrentTimeoutError:
+        return QBittorrentTestResult(ok=False, error="connection timeout")
+    except QBittorrentError as exc:
+        return QBittorrentTestResult(ok=False, error=str(exc))
+
+
+def _row_to_out(row: object, cfg: dict[str, Any]) -> QBittorrentConfigOut:
+    from app.models.integration_config import IntegrationConfig
+
+    assert isinstance(row, IntegrationConfig)
+    return QBittorrentConfigOut(
+        id=row.id,
+        name=row.name,
+        host=cfg["host"],
+        port=cfg["port"],
+        username=cfg["username"],
+        use_https=cfg.get("use_https", False),
+        enabled=row.enabled,
+        last_test_at=row.last_test_at,
+        last_test_ok=row.last_test_ok,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+async def get_config(session: AsyncSession) -> QBittorrentConfigOut | None:
+    repo = IntegrationConfigRepository(session)
+    row = await repo.get_by_type(_TYPE)
+    if row is None:
+        return None
+    return _row_to_out(row, decrypt_config(row.config))
+
+
+async def upsert_config(
+    session: AsyncSession, config_in: QBittorrentConfigIn
+) -> QBittorrentConfigOut:
+    repo = IntegrationConfigRepository(session)
+    config_dict = {
+        "host": config_in.host,
+        "port": config_in.port,
+        "username": config_in.username,
+        "password": config_in.password,
+        "use_https": config_in.use_https,
+    }
+    row = await repo.upsert(
+        _TYPE,
+        name=config_in.name,
+        config_bytes=encrypt_config(config_dict),
+        enabled=config_in.enabled,
+    )
+    return _row_to_out(row, config_dict)
+
+
+async def delete_config(session: AsyncSession) -> bool:
+    repo = IntegrationConfigRepository(session)
+    return await repo.delete_by_type(_TYPE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import os
+
+# Must be set before app.core.config is imported (Settings() runs at module level).
+os.environ.setdefault("LIBRARR_SECRET_KEY", "1n3vmcNiJofBGpYnnfPZiNft8EKPp8iba8UpfQTLigY=")
+
 import json
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field

--- a/tests/integration/test_integrations_api.py
+++ b/tests/integration/test_integrations_api.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from app.integrations.exceptions import (
+    QBittorrentAuthError,
+    QBittorrentForbiddenError,
+    QBittorrentTimeoutError,
+)
+from app.schemas.qbittorrent import QBittorrentHealth
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_PAYLOAD = {
+    "name": "Local qBit",
+    "host": "localhost",
+    "port": 8080,
+    "username": "admin",
+    "password": "s3cr3t",
+    "use_https": False,
+    "enabled": True,
+}
+
+
+def make_mock_build_client(
+    health_return: QBittorrentHealth | None = None,
+    health_side_effect: Exception | None = None,
+) -> object:
+    @contextlib.asynccontextmanager
+    async def _ctx(*args: object, **kwargs: object) -> AsyncGenerator[AsyncMock]:
+        mock_client = AsyncMock()
+        if health_side_effect is not None:
+            mock_client.health = AsyncMock(side_effect=health_side_effect)
+        else:
+            mock_client.health = AsyncMock(return_value=health_return)
+        yield mock_client
+
+    return _ctx
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/integrations/qbittorrent
+# ---------------------------------------------------------------------------
+
+
+async def test_get_returns_null_when_not_configured(api_client: httpx.AsyncClient) -> None:
+    response = await api_client.get("/api/v1/integrations/qbittorrent")
+    assert response.status_code == 200
+    assert response.json() is None
+
+
+async def test_get_returns_config_after_put(api_client: httpx.AsyncClient) -> None:
+    await api_client.put("/api/v1/integrations/qbittorrent", json=_VALID_PAYLOAD)
+
+    response = await api_client.get("/api/v1/integrations/qbittorrent")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["host"] == "localhost"
+    assert data["username"] == "admin"
+    assert "password" not in data
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/v1/integrations/qbittorrent
+# ---------------------------------------------------------------------------
+
+
+async def test_put_creates_config(api_client: httpx.AsyncClient) -> None:
+    response = await api_client.put("/api/v1/integrations/qbittorrent", json=_VALID_PAYLOAD)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Local qBit"
+    assert data["host"] == "localhost"
+    assert data["port"] == 8080
+    assert "password" not in data
+
+
+async def test_put_replaces_existing_config(api_client: httpx.AsyncClient) -> None:
+    await api_client.put("/api/v1/integrations/qbittorrent", json=_VALID_PAYLOAD)
+
+    updated = {**_VALID_PAYLOAD, "host": "192.168.1.10", "port": 9090, "name": "Updated"}
+    response = await api_client.put("/api/v1/integrations/qbittorrent", json=updated)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["host"] == "192.168.1.10"
+    assert data["port"] == 9090
+    assert data["name"] == "Updated"
+
+
+async def test_put_returns_422_for_invalid_port(api_client: httpx.AsyncClient) -> None:
+    bad = {**_VALID_PAYLOAD, "port": 99999}
+    response = await api_client.put("/api/v1/integrations/qbittorrent", json=bad)
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/integrations/qbittorrent
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_returns_204(api_client: httpx.AsyncClient) -> None:
+    await api_client.put("/api/v1/integrations/qbittorrent", json=_VALID_PAYLOAD)
+    response = await api_client.delete("/api/v1/integrations/qbittorrent")
+    assert response.status_code == 204
+
+
+async def test_delete_returns_404_when_not_configured(api_client: httpx.AsyncClient) -> None:
+    response = await api_client.delete("/api/v1/integrations/qbittorrent")
+    assert response.status_code == 404
+
+
+async def test_delete_then_get_returns_null(api_client: httpx.AsyncClient) -> None:
+    await api_client.put("/api/v1/integrations/qbittorrent", json=_VALID_PAYLOAD)
+    await api_client.delete("/api/v1/integrations/qbittorrent")
+
+    response = await api_client.get("/api/v1/integrations/qbittorrent")
+    assert response.status_code == 200
+    assert response.json() is None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/integrations/qbittorrent/test
+# ---------------------------------------------------------------------------
+
+_TEST_PAYLOAD = {
+    "host": "localhost",
+    "port": 8080,
+    "username": "admin",
+    "password": "s3cr3t",
+    "use_https": False,
+}
+
+
+async def test_test_endpoint_success(api_client: httpx.AsyncClient) -> None:
+    mock_factory = make_mock_build_client(health_return=QBittorrentHealth(version="v5.0.5"))
+    with patch("app.services.qbittorrent_service._build_client", mock_factory):
+        response = await api_client.post(
+            "/api/v1/integrations/qbittorrent/test", json=_TEST_PAYLOAD
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["version"] == "v5.0.5"
+
+
+async def test_test_endpoint_auth_failure(api_client: httpx.AsyncClient) -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=QBittorrentAuthError("bad creds")
+    )
+    with patch("app.services.qbittorrent_service._build_client", mock_factory):
+        response = await api_client.post(
+            "/api/v1/integrations/qbittorrent/test", json=_TEST_PAYLOAD
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert data["error"] == "invalid credentials"
+
+
+async def test_test_endpoint_timeout(api_client: httpx.AsyncClient) -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=QBittorrentTimeoutError("timeout")
+    )
+    with patch("app.services.qbittorrent_service._build_client", mock_factory):
+        response = await api_client.post(
+            "/api/v1/integrations/qbittorrent/test", json=_TEST_PAYLOAD
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert data["error"] == "connection timeout"
+
+
+async def test_test_endpoint_forbidden(api_client: httpx.AsyncClient) -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=QBittorrentForbiddenError("forbidden")
+    )
+    with patch("app.services.qbittorrent_service._build_client", mock_factory):
+        response = await api_client.post(
+            "/api/v1/integrations/qbittorrent/test", json=_TEST_PAYLOAD
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert "Server domains" in data["error"]

--- a/tests/integration/test_qbittorrent_service.py
+++ b/tests/integration/test_qbittorrent_service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.exceptions import (
+    QBittorrentAuthError,
+    QBittorrentForbiddenError,
+    QBittorrentTimeoutError,
+)
+from app.schemas.qbittorrent import QBittorrentConfigIn, QBittorrentHealth, QBittorrentTestResult
+from app.services import qbittorrent_service as svc
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CONFIG_IN = QBittorrentConfigIn(
+    name="Local qBit",
+    host="localhost",
+    port=8080,
+    username="admin",
+    password="s3cr3t",
+    use_https=False,
+    enabled=True,
+)
+
+
+def make_mock_build_client(
+    health_return: QBittorrentHealth | None = None,
+    health_side_effect: Exception | None = None,
+) -> object:
+    @contextlib.asynccontextmanager
+    async def _ctx(*args: object, **kwargs: object) -> AsyncGenerator[AsyncMock]:
+        mock_client = AsyncMock()
+        if health_side_effect is not None:
+            mock_client.health = AsyncMock(side_effect=health_side_effect)
+        else:
+            mock_client.health = AsyncMock(return_value=health_return)
+        yield mock_client
+
+    return _ctx
+
+
+# ---------------------------------------------------------------------------
+# CRUD — upsert / get / delete
+# ---------------------------------------------------------------------------
+
+
+async def test_upsert_creates_new_config(db_session: AsyncSession) -> None:
+    result = await svc.upsert_config(db_session, _CONFIG_IN)
+
+    assert result.name == "Local qBit"
+    assert result.host == "localhost"
+    assert result.port == 8080
+    assert result.username == "admin"
+    assert result.use_https is False
+    assert result.enabled is True
+    assert not hasattr(result, "password")
+
+
+async def test_upsert_replaces_existing_config(db_session: AsyncSession) -> None:
+    await svc.upsert_config(db_session, _CONFIG_IN)
+
+    updated = QBittorrentConfigIn(
+        name="Updated qBit",
+        host="192.168.1.10",
+        port=9090,
+        username="newuser",
+        password="newpass",
+        use_https=True,
+        enabled=False,
+    )
+    result = await svc.upsert_config(db_session, updated)
+
+    assert result.name == "Updated qBit"
+    assert result.host == "192.168.1.10"
+    assert result.port == 9090
+    assert result.username == "newuser"
+    assert result.use_https is True
+    assert result.enabled is False
+
+    # Only one row in DB
+    second_get = await svc.get_config(db_session)
+    assert second_get is not None
+    assert second_get.host == "192.168.1.10"
+
+
+async def test_get_returns_decrypted_config_without_password(db_session: AsyncSession) -> None:
+    await svc.upsert_config(db_session, _CONFIG_IN)
+
+    result = await svc.get_config(db_session)
+
+    assert result is not None
+    assert result.host == "localhost"
+    assert result.username == "admin"
+    assert not hasattr(result, "password")
+
+
+async def test_get_returns_none_when_not_configured(db_session: AsyncSession) -> None:
+    result = await svc.get_config(db_session)
+    assert result is None
+
+
+async def test_delete_returns_true_when_exists(db_session: AsyncSession) -> None:
+    await svc.upsert_config(db_session, _CONFIG_IN)
+    assert await svc.delete_config(db_session) is True
+
+
+async def test_delete_returns_false_when_not_configured(db_session: AsyncSession) -> None:
+    assert await svc.delete_config(db_session) is False
+
+
+# ---------------------------------------------------------------------------
+# test_connection — mock _build_client
+# ---------------------------------------------------------------------------
+
+
+async def test_test_connection_success() -> None:
+    mock_factory = make_mock_build_client(
+        health_return=QBittorrentHealth(version="v5.0.5")
+    )
+    with patch("app.services.qbittorrent_service._build_client", mock_factory):
+        result = await svc.test_connection("localhost", 8080, "admin", "pass", False)
+
+    assert result == QBittorrentTestResult(ok=True, version="v5.0.5")
+
+
+async def test_test_connection_auth_failure() -> None:
+    mock_factory = make_mock_build_client(health_side_effect=QBittorrentAuthError("bad creds"))
+    with patch("app.services.qbittorrent_service._build_client", mock_factory):
+        result = await svc.test_connection("localhost", 8080, "admin", "wrong", False)
+
+    assert result == QBittorrentTestResult(ok=False, error="invalid credentials")
+
+
+async def test_test_connection_timeout() -> None:
+    mock_factory = make_mock_build_client(health_side_effect=QBittorrentTimeoutError("timeout"))
+    with patch("app.services.qbittorrent_service._build_client", mock_factory):
+        result = await svc.test_connection("localhost", 8080, "admin", "pass", False)
+
+    assert result == QBittorrentTestResult(ok=False, error="connection timeout")
+
+
+async def test_test_connection_forbidden() -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=QBittorrentForbiddenError("forbidden")
+    )
+    with patch("app.services.qbittorrent_service._build_client", mock_factory):
+        result = await svc.test_connection("localhost", 8080, "admin", "pass", False)
+
+    assert result == QBittorrentTestResult(
+        ok=False,
+        error="forbidden — check Server domains in qBittorrent Web UI settings",
+    )

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.core.crypto import decrypt_config, encrypt_config
+
+
+def test_round_trip_preserves_data() -> None:
+    data = {"host": "localhost", "port": 8080, "username": "admin", "password": "s3cr3t"}
+    ciphertext = encrypt_config(data)
+    assert decrypt_config(ciphertext) == data
+
+
+def test_ciphertext_is_bytes() -> None:
+    ciphertext = encrypt_config({"key": "value"})
+    assert isinstance(ciphertext, bytes)
+
+
+def test_wrong_key_raises_invalid_token() -> None:
+    ciphertext = encrypt_config({"key": "value"})
+
+    other_key = Fernet.generate_key()
+    other_fernet = Fernet(other_key)
+
+    with pytest.raises(InvalidToken):
+        other_fernet.decrypt(ciphertext)


### PR DESCRIPTION
## Summary

Persists qBittorrent integration config in DB with Fernet-encrypted credentials and exposes CRUD + stateless test endpoints. Single-instance enforcement at the repository layer (one qBittorrent config per librarr install).

Builds on the qBittorrent client from #7.

## Changes

- **Encryption:** `LIBRARR_SECRET_KEY` env var (required, validated as Fernet key at startup). New `app/core/crypto.py` with `encrypt_config` / `decrypt_config` helpers.
- **Schemas:** `QBittorrentConfigIn`, `QBittorrentConfigOut` (never includes password), `QBittorrentTestRequest`, `QBittorrentTestResult`.
- **Repository:** `IntegrationConfigRepository` with `get_by_type`, `upsert`, `delete_by_type`, `update_test_result` — single-instance via type-keyed upsert.
- **Service:** `qbittorrent_service` with stateless `test_connection` (credentials from request, never touches DB), `get_config` / `upsert_config` / `delete_config` for persistence.
- **API:**
  - `GET /api/v1/integrations/qbittorrent` → config or null
  - `PUT /api/v1/integrations/qbittorrent` → upsert
  - `DELETE /api/v1/integrations/qbittorrent` → 204 / 404
  - `POST /api/v1/integrations/qbittorrent/test` → stateless test, failure in body not status
- **Tests:** 25 new (10 service, 12 API, 3 crypto). Test secret key set via `os.environ.setdefault` at top of `conftest.py` before `app.*` imports.

## Verification

uv run ruff check  → all checks passed
uv run mypy        → no new errors (13 pre-existing in book.py / book_service.py)
uv run pytest      → 120 passed (95 prior + 25 new), 0 regressions

## Out of scope

- Frontend Settings → Integrations UI (next feature)
- Multi-instance qBittorrent support
- Re-test on schedule / health monitoring
- Prowlarr → qBit download orchestration

## Notes

- One `# type: ignore[attr-defined]` added in repository for `Result.rowcount`, matching existing pattern in `book.py:194,204`. Tracked as tech debt — see `docs/FOLLOWUPS.md` (or to be added).