### PR TITLE
feat(web): add qbittorrent download client settings UI

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
+        "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.100.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -16,9 +17,11 @@
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-hook-form": "^7.75.0",
         "shadcn": "^4.6.0",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -941,6 +944,18 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2034,6 +2049,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -8048,6 +8069,22 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9908,9 +9945,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
-      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.100.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -17,9 +18,11 @@
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-hook-form": "^7.75.0",
     "shadcn": "^4.6.0",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/web/src/app/(dashboard)/download-clients/page.tsx
+++ b/web/src/app/(dashboard)/download-clients/page.tsx
@@ -1,7 +1,105 @@
-export default function DownloadClientsPage() {
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { PlusIcon, CheckCircleIcon, XCircleIcon, MinusCircleIcon } from "lucide-react";
+import { qbittorrentQueries } from "@/lib/queries";
+import { fmtDate } from "@/lib/fmt";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import type { QBittorrentConfig } from "@/lib/types";
+
+function StatusBadge({ config }: { config: QBittorrentConfig }) {
+  if (config.last_test_ok === null) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+        <MinusCircleIcon className="size-3.5" />
+        Untested
+      </span>
+    );
+  }
+  if (config.last_test_ok) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+        <CheckCircleIcon className="size-3.5" />
+        OK
+        {config.last_test_at && (
+          <span className="text-muted-foreground">· {fmtDate(config.last_test_at)}</span>
+        )}
+      </span>
+    );
+  }
   return (
-    <div className="flex h-full items-center justify-center">
-      <p className="text-text-3 text-sm font-mono">Download Clients — coming in v0.1.x</p>
+    <span className="inline-flex items-center gap-1 text-xs text-destructive">
+      <XCircleIcon className="size-3.5" />
+      Failed
+      {config.last_test_at && (
+        <span className="text-muted-foreground">· {fmtDate(config.last_test_at)}</span>
+      )}
+    </span>
+  );
+}
+
+export default function DownloadClientsPage() {
+  const router = useRouter();
+  const { data: config, isLoading } = useQuery(qbittorrentQueries.config());
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground text-sm">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!config) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4">
+        <p className="text-muted-foreground text-sm">No download clients configured.</p>
+        <Button onClick={() => router.push("/download-clients/qbittorrent")}>
+          <PlusIcon />
+          Add Download Client
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+          Download Clients
+        </h2>
+        <Button
+          size="sm"
+          onClick={() => router.push("/download-clients/qbittorrent")}
+        >
+          <PlusIcon />
+          Add
+        </Button>
+      </div>
+
+      <Card
+        className="cursor-pointer transition-colors hover:bg-muted/30"
+        onClick={() => router.push("/download-clients/qbittorrent")}
+      >
+        <CardContent className="flex items-center gap-4 py-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium truncate">{config.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {config.use_https ? "https" : "http"}://{config.host}:{config.port}
+            </p>
+          </div>
+          <div className="flex items-center gap-3 shrink-0">
+            {!config.enabled && (
+              <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                Disabled
+              </span>
+            )}
+            <StatusBadge config={config} />
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/web/src/app/(dashboard)/download-clients/qbittorrent/page.tsx
+++ b/web/src/app/(dashboard)/download-clients/qbittorrent/page.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { CheckCircleIcon, XCircleIcon, Loader2Icon, Trash2Icon } from "lucide-react";
+import { qbittorrentQueries, queryKeys } from "@/lib/queries";
+import { integrationsApi } from "@/lib/api/integrations";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
+import type { QBittorrentTestResult } from "@/lib/types";
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+
+const formSchema = z.object({
+  name: z.string().min(1, "Required").max(100),
+  host: z.string().min(1, "Required"),
+  port: z.coerce.number().int().min(1).max(65535),
+  username: z.string().min(1, "Required"),
+  password: z.string().min(1, "Required"),
+  use_https: z.boolean(),
+  enabled: z.boolean(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+// ── Test result banner ────────────────────────────────────────────────────────
+
+function TestResultBanner({ result }: { result: QBittorrentTestResult }) {
+  if (result.ok) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-400">
+        <CheckCircleIcon className="size-4 shrink-0" />
+        Connected to qBittorrent{result.version ? ` v${result.version}` : ""}
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      <XCircleIcon className="size-4 shrink-0" />
+      {result.error ?? "Connection failed"}
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function QBittorrentConfigPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [testResult, setTestResult] = useState<QBittorrentTestResult | null>(null);
+
+  const { data: existing, isLoading } = useQuery(qbittorrentQueries.config());
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema) as Resolver<FormValues>,
+    defaultValues: {
+      name: "",
+      host: "",
+      port: 8080,
+      username: "",
+      password: "",
+      use_https: false,
+      enabled: true,
+    },
+    values: existing
+      ? {
+          name: existing.name,
+          host: existing.host,
+          port: existing.port,
+          username: existing.username,
+          password: "",
+          use_https: existing.use_https,
+          enabled: existing.enabled,
+        }
+      : undefined,
+  });
+
+  const testMutation = useMutation({
+    mutationFn: (vals: FormValues) =>
+      integrationsApi.testQBittorrent({
+        host: vals.host,
+        port: vals.port,
+        username: vals.username,
+        password: vals.password,
+        use_https: vals.use_https,
+      }),
+    onSuccess: (result) => setTestResult(result),
+    onError: () =>
+      setTestResult({ ok: false, version: null, error: "Request failed" }),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (vals: FormValues) => integrationsApi.upsertQBittorrent(vals),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.integrations.qbittorrent(),
+      });
+      router.push("/download-clients");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => integrationsApi.deleteQBittorrent(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.integrations.qbittorrent(),
+      });
+      router.push("/download-clients");
+    },
+  });
+
+  const onTest = form.handleSubmit((vals) => {
+    setTestResult(null);
+    testMutation.mutate(vals);
+  });
+
+  const onSave = form.handleSubmit((vals) => {
+    saveMutation.mutate(vals);
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground text-sm">Loading…</p>
+      </div>
+    );
+  }
+
+  const isEdit = !!existing;
+
+  return (
+    <div className="p-6 max-w-xl">
+      <div className="mb-6">
+        <h2 className="text-base font-semibold">
+          {isEdit ? "Edit qBittorrent" : "Add qBittorrent"}
+        </h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Configure your qBittorrent download client.
+        </p>
+      </div>
+
+      <Form {...form}>
+        <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+          <Card>
+            <CardHeader>
+              <CardTitle>Connection</CardTitle>
+              <CardDescription>Network settings for your qBittorrent instance.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Local qBittorrent" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="grid grid-cols-3 gap-3">
+                <FormField
+                  control={form.control}
+                  name="host"
+                  render={({ field }) => (
+                    <FormItem className="col-span-2">
+                      <FormLabel>Host</FormLabel>
+                      <FormControl>
+                        <Input placeholder="localhost" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="port"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Port</FormLabel>
+                      <FormControl>
+                        <Input type="number" placeholder="8080" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="use_https"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between rounded-lg border border-border px-3 py-2.5">
+                    <div>
+                      <FormLabel>Use HTTPS</FormLabel>
+                      <FormDescription>
+                        Enable if qBittorrent is served over HTTPS.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Authentication</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <FormField
+                control={form.control}
+                name="username"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Username</FormLabel>
+                    <FormControl>
+                      <Input placeholder="admin" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <FormControl>
+                      <Input type="password" placeholder="••••••••" {...field} />
+                    </FormControl>
+                    {isEdit && (
+                      <FormDescription>
+                        Password is not stored in plaintext. Re-enter to save changes.
+                      </FormDescription>
+                    )}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="pt-6">
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between">
+                    <div>
+                      <FormLabel>Enabled</FormLabel>
+                      <FormDescription>
+                        When disabled, librarr will not send downloads to this client.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          {testResult && <TestResultBanner result={testResult} />}
+
+          {saveMutation.error && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              Save failed:{" "}
+              {saveMutation.error instanceof Error
+                ? saveMutation.error.message
+                : "Unknown error"}
+            </div>
+          )}
+
+          <div className="flex items-center gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={testMutation.isPending}
+              onClick={onTest}
+            >
+              {testMutation.isPending && (
+                <Loader2Icon className="animate-spin" />
+              )}
+              Test Connection
+            </Button>
+
+            <Button
+              type="button"
+              disabled={saveMutation.isPending}
+              onClick={onSave}
+            >
+              {saveMutation.isPending && (
+                <Loader2Icon className="animate-spin" />
+              )}
+              Save
+            </Button>
+
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => router.push("/download-clients")}
+            >
+              Cancel
+            </Button>
+
+            {isEdit && (
+              <div className="ml-auto">
+                <AlertDialog>
+                  <AlertDialogTrigger
+                    render={
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        disabled={deleteMutation.isPending}
+                      />
+                    }
+                  >
+                    {deleteMutation.isPending ? (
+                      <Loader2Icon className="animate-spin" />
+                    ) : (
+                      <Trash2Icon />
+                    )}
+                    Delete
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete qBittorrent?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This will remove the qBittorrent configuration. Active downloads
+                        will not be affected.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        variant="destructive"
+                        onClick={() => deleteMutation.mutate()}
+                      >
+                        Delete
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            )}
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { Button, buttonVariants } from "@/components/ui/button"
+import type { VariantProps } from "class-variance-authority"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: AlertDialogPrimitive.Popup.Props) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({ className, ...props }: AlertDialogPrimitive.Title.Props) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("font-heading text-base leading-none font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: AlertDialogPrimitive.Description.Props) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-action"
+      render={<Button variant={variant} size={size} />}
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: AlertDialogPrimitive.Close.Props) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      render={<Button variant="outline" />}
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -1,0 +1,67 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "rounded-xl border border-border bg-card text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn("flex flex-col gap-1.5 p-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("p-6 pt-0", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center p-6 pt-0", className)}
+      {...props}
+    />
+  )
+}
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }

--- a/web/src/components/ui/form.tsx
+++ b/web/src/components/ui/form.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+import * as React from "react"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+// ── Context ───────────────────────────────────────────────────────────────────
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+// ── useFormField ──────────────────────────────────────────────────────────────
+
+function useFormField() {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField must be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+// ── Form (alias for FormProvider) ─────────────────────────────────────────────
+
+const Form = FormProvider
+
+// ── FormField ─────────────────────────────────────────────────────────────────
+
+function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({ ...props }: ControllerProps<TFieldValues, TName>) {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+// ── FormItem ──────────────────────────────────────────────────────────────────
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("flex flex-col gap-1.5", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+}
+
+// ── FormLabel ─────────────────────────────────────────────────────────────────
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      data-slot="form-label"
+      htmlFor={formItemId}
+      className={cn(error && "text-destructive", className)}
+      {...props}
+    />
+  )
+}
+
+// ── FormControl ───────────────────────────────────────────────────────────────
+
+function FormControl({ children }: { children: React.ReactElement }) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return React.cloneElement(children, {
+    id: (children.props as { id?: string }).id ?? formItemId,
+    "aria-describedby": !error
+      ? formDescriptionId
+      : `${formDescriptionId} ${formMessageId}`,
+    "aria-invalid": !!error || undefined,
+  } as object)
+}
+
+// ── FormDescription ───────────────────────────────────────────────────────────
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+// ── FormMessage ───────────────────────────────────────────────────────────────
+
+function FormMessage({ className, children, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? error) : children
+
+  if (!body) return null
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-xs font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: SwitchPrimitive.Root.Props) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-primary data-[unchecked]:bg-input",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[checked]:translate-x-4 data-[unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/web/src/lib/api/integrations.ts
+++ b/web/src/lib/api/integrations.ts
@@ -1,0 +1,29 @@
+import { apiFetch } from "./client";
+import type {
+  QBittorrentConfig,
+  QBittorrentConfigInput,
+  QBittorrentTestRequest,
+  QBittorrentTestResult,
+} from "@/lib/types";
+
+export const integrationsApi = {
+  getQBittorrent: (): Promise<QBittorrentConfig | null> =>
+    apiFetch<QBittorrentConfig | null>("/api/v1/integrations/qbittorrent"),
+
+  upsertQBittorrent: (input: QBittorrentConfigInput): Promise<QBittorrentConfig> =>
+    apiFetch<QBittorrentConfig>("/api/v1/integrations/qbittorrent", {
+      method: "PUT",
+      body: JSON.stringify(input),
+    }),
+
+  deleteQBittorrent: (): Promise<void> =>
+    apiFetch<void>("/api/v1/integrations/qbittorrent", {
+      method: "DELETE",
+    }),
+
+  testQBittorrent: (req: QBittorrentTestRequest): Promise<QBittorrentTestResult> =>
+    apiFetch<QBittorrentTestResult>("/api/v1/integrations/qbittorrent/test", {
+      method: "POST",
+      body: JSON.stringify(req),
+    }),
+};

--- a/web/src/lib/mock/integrations.ts
+++ b/web/src/lib/mock/integrations.ts
@@ -1,0 +1,15 @@
+import type { QBittorrentConfig } from "@/lib/types";
+
+export const MOCK_QBITTORRENT_CONFIG: QBittorrentConfig = {
+  id: "019700000000000000000000000000aa",
+  name: "Local qBittorrent",
+  host: "localhost",
+  port: 8080,
+  username: "admin",
+  use_https: false,
+  enabled: true,
+  last_test_at: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
+  last_test_ok: true,
+  created_at: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+  updated_at: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
+};

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,10 +1,12 @@
 import { MOCK_BOOKS } from "./mock/books";
 import { MOCK_QUEUE_ITEMS } from "./mock/queue";
 import { MOCK_SYSTEM_STATUS } from "./mock/system";
+import { MOCK_QBITTORRENT_CONFIG } from "./mock/integrations";
 import { withMockFallback } from "./use-mock";
 import { booksApi } from "./api/books";
 import { queueApi } from "./api/queue";
 import { systemApi } from "./api/system";
+import { integrationsApi } from "./api/integrations";
 import type { BookListParams } from "./types";
 
 export const queryKeys = {
@@ -19,6 +21,10 @@ export const queryKeys = {
   },
   system: {
     status: () => ["system", "status"] as const,
+  },
+  integrations: {
+    all: ["integrations"] as const,
+    qbittorrent: () => ["integrations", "qbittorrent"] as const,
   },
 } as const;
 
@@ -51,5 +57,16 @@ export const systemQueries = {
     queryKey: queryKeys.system.status(),
     queryFn: () =>
       withMockFallback(() => systemApi.getStatus(), MOCK_SYSTEM_STATUS),
+  }),
+};
+
+export const qbittorrentQueries = {
+  config: () => ({
+    queryKey: queryKeys.integrations.qbittorrent(),
+    queryFn: () =>
+      withMockFallback(
+        () => integrationsApi.getQBittorrent(),
+        MOCK_QBITTORRENT_CONFIG,
+      ),
   }),
 };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -347,6 +347,46 @@ export interface CommandResponse {
   body: Record<string, unknown>;
 }
 
+// ── Integrations ─────────────────────────────────────────────────────────────
+
+export type QBittorrentConfig = {
+  id: string;
+  name: string;
+  host: string;
+  port: number;
+  username: string;
+  use_https: boolean;
+  enabled: boolean;
+  last_test_at: string | null;
+  last_test_ok: boolean | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type QBittorrentConfigInput = {
+  name: string;
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  use_https: boolean;
+  enabled: boolean;
+};
+
+export type QBittorrentTestRequest = {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  use_https: boolean;
+};
+
+export type QBittorrentTestResult = {
+  ok: boolean;
+  version: string | null;
+  error: string | null;
+};
+
 // ── API error ─────────────────────────────────────────────────────────────────
 
 export interface APIError {


### PR DESCRIPTION
## Summary

Wires up the qBittorrent download client settings UI on top of the backend endpoints from PR #8. Users can now add, edit, test, and delete a qBittorrent configuration through the web interface — no more curl/Postman to dogfood the integration.

## Changes

- **Form stack:** `react-hook-form` + `zod` + `@hookform/resolvers` adopted as the standard for all future integration/settings forms (Calibre, Prowlarr, indexers, quality profiles).
- **UI primitives:** Hand-added `form`, `label`, `switch`, `card`, `alert-dialog` matching the codebase's `base-nova` shadcn variant. All built on `@base-ui/react` — no `@radix-ui` packages introduced.
- **Types:** `QBittorrentConfig`, `QBittorrentConfigInput`, `QBittorrentTestRequest`, `QBittorrentTestResult` in snake_case to mirror backend Pydantic schemas exactly.
- **API module:** `integrationsApi` with `getQBittorrent` / `upsertQBittorrent` / `deleteQBittorrent` / `testQBittorrent`, mirroring the existing `booksApi` / `queueApi` pattern over `apiFetch`.
- **Query factory:** `qbittorrentQueries.config` + `queryKeys.integrations.qbittorrent()` keyed on `["integrations", "qbittorrent"]`.
- **Mock:** `MOCK_QBITTORRENT_CONFIG` for `NEXT_PUBLIC_USE_MOCK=true` UI dev.
- **Pages:**
  - `/download-clients` — list view with empty state + Add button; configured config shows host:port, enabled state, and last-test status badge (OK / Failed / Untested with timestamp).
  - `/download-clients/qbittorrent` — config form (create + edit), inline Test Connection (against form values, not saved values), Save (upsert + invalidate), Delete (AlertDialog confirm) on edit. Password field intentionally requires re-entry on edit since the backend never returns it.

## Verification

npm run lint   → clean
npm run build  → 15 pages, TypeScript check passes, both new routes render

## Notes

- `zodResolver(formSchema) as Resolver<FormValues>` — Zod v4's `z.coerce.number()` has `unknown` input type, mismatched with RHF's `Resolver<FormValues>`. Runtime behavior is identical; cast is the upstream-recommended workaround until the typing is fixed in `@hookform/resolvers`.
- `FormControl` uses `React.cloneElement` to forward `id` / `aria-*` to children — the Base UI equivalent of Radix's `Slot` pattern, kept minimal.

## Out of scope

- Toast/snackbar system (uses inline banners instead)
- Other integration UIs (Calibre, Prowlarr, indexers)
- Multi-instance qBittorrent
- Prowlarr → qBit download orchestration (next feature, 3.x)