### PR TITLE
feat(integrations): add Prowlarr settings management (3.1)

### DIFF
--- a/app/api/v1/integrations.py
+++ b/app/api/v1/integrations.py
@@ -5,8 +5,15 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import app.services.prowlarr_service as prowlarr_service
 import app.services.qbittorrent_service as qbt_service
 from app.core.db import get_db
+from app.schemas.prowlarr import (
+    ProwlarrConfigIn,
+    ProwlarrConfigOut,
+    ProwlarrTestRequest,
+    ProwlarrTestResult,
+)
 from app.schemas.qbittorrent import (
     QBittorrentConfigIn,
     QBittorrentConfigOut,
@@ -43,3 +50,25 @@ async def test_qbittorrent(body: QBittorrentTestRequest) -> QBittorrentTestResul
     return await qbt_service.test_connection(
         body.host, body.port, body.username, body.password, body.use_https
     )
+
+
+@router.get("/prowlarr", response_model=ProwlarrConfigOut | None)
+async def get_prowlarr(session: _DB) -> ProwlarrConfigOut | None:
+    return await prowlarr_service.get_config(session)
+
+
+@router.put("/prowlarr", response_model=ProwlarrConfigOut)
+async def upsert_prowlarr(body: ProwlarrConfigIn, session: _DB) -> ProwlarrConfigOut:
+    return await prowlarr_service.upsert_config(session, body)
+
+
+@router.delete("/prowlarr", status_code=204)
+async def delete_prowlarr(session: _DB) -> None:
+    deleted = await prowlarr_service.delete_config(session)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Prowlarr not configured")
+
+
+@router.post("/prowlarr/test", response_model=ProwlarrTestResult)
+async def test_prowlarr(body: ProwlarrTestRequest) -> ProwlarrTestResult:
+    return await prowlarr_service.test_connection(body.base_url, body.api_key)

--- a/app/schemas/prowlarr.py
+++ b/app/schemas/prowlarr.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ProwlarrRelease(BaseModel):
@@ -26,3 +27,32 @@ class ProwlarrHealth(BaseModel):
 
     version: str
     app_name: str
+
+
+class ProwlarrConfigIn(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    base_url: str = Field(min_length=1)
+    api_key: str = Field(min_length=1)
+    enabled: bool = True
+
+
+class ProwlarrConfigOut(BaseModel):
+    id: uuid.UUID
+    name: str
+    base_url: str
+    enabled: bool
+    last_test_at: datetime | None
+    last_test_ok: bool | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProwlarrTestRequest(BaseModel):
+    base_url: str
+    api_key: str
+
+
+class ProwlarrTestResult(BaseModel):
+    ok: bool
+    version: str | None = None
+    error: str | None = None

--- a/app/services/prowlarr_service.py
+++ b/app/services/prowlarr_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.crypto import decrypt_config, encrypt_config
+from app.integrations.exceptions import (
+    ProwlarrAuthError,
+    ProwlarrError,
+    ProwlarrTimeoutError,
+)
+from app.integrations.prowlarr.client import ProwlarrClient
+from app.repositories.integration_config import IntegrationConfigRepository
+from app.schemas.prowlarr import (
+    ProwlarrConfigIn,
+    ProwlarrConfigOut,
+    ProwlarrTestResult,
+)
+
+_TYPE = "prowlarr"
+
+
+@contextlib.asynccontextmanager
+async def _build_client(base_url: str, api_key: str) -> AsyncGenerator[ProwlarrClient]:
+    async with httpx.AsyncClient(
+        base_url=base_url,
+        timeout=httpx.Timeout(
+            settings.http_timeout_read,
+            connect=settings.http_timeout_connect,
+        ),
+    ) as http:
+        yield ProwlarrClient(http, api_key=api_key)
+
+
+async def test_connection(base_url: str, api_key: str) -> ProwlarrTestResult:
+    try:
+        async with _build_client(base_url, api_key) as client:
+            health = await client.health()
+        return ProwlarrTestResult(ok=True, version=health.version)
+    except ProwlarrAuthError:
+        return ProwlarrTestResult(ok=False, error="invalid API key")
+    except ProwlarrTimeoutError:
+        return ProwlarrTestResult(ok=False, error="connection timeout")
+    except ProwlarrError as exc:
+        return ProwlarrTestResult(ok=False, error=str(exc))
+
+
+def _row_to_out(row: object, cfg: dict[str, Any]) -> ProwlarrConfigOut:
+    from app.models.integration_config import IntegrationConfig
+
+    assert isinstance(row, IntegrationConfig)
+    return ProwlarrConfigOut(
+        id=row.id,
+        name=row.name,
+        base_url=cfg["base_url"],
+        enabled=row.enabled,
+        last_test_at=row.last_test_at,
+        last_test_ok=row.last_test_ok,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+async def get_config(session: AsyncSession) -> ProwlarrConfigOut | None:
+    repo = IntegrationConfigRepository(session)
+    row = await repo.get_by_type(_TYPE)
+    if row is None:
+        return None
+    return _row_to_out(row, decrypt_config(row.config))
+
+
+async def upsert_config(
+    session: AsyncSession, config_in: ProwlarrConfigIn
+) -> ProwlarrConfigOut:
+    repo = IntegrationConfigRepository(session)
+    config_dict = {
+        "base_url": config_in.base_url,
+        "api_key": config_in.api_key,
+    }
+    row = await repo.upsert(
+        _TYPE,
+        name=config_in.name,
+        config_bytes=encrypt_config(config_dict),
+        enabled=config_in.enabled,
+    )
+    return _row_to_out(row, config_dict)
+
+
+async def delete_config(session: AsyncSession) -> bool:
+    repo = IntegrationConfigRepository(session)
+    return await repo.delete_by_type(_TYPE)

--- a/tests/integration/test_prowlarr_settings_api.py
+++ b/tests/integration/test_prowlarr_settings_api.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from app.integrations.exceptions import (
+    ProwlarrAuthError,
+    ProwlarrServerError,
+    ProwlarrTimeoutError,
+)
+from app.schemas.prowlarr import ProwlarrHealth
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_PAYLOAD = {
+    "name": "Local Prowlarr",
+    "base_url": "http://localhost:9696",
+    "api_key": "abc123",
+    "enabled": True,
+}
+
+_TEST_PAYLOAD = {
+    "base_url": "http://localhost:9696",
+    "api_key": "abc123",
+}
+
+
+def make_mock_build_client(
+    health_return: ProwlarrHealth | None = None,
+    health_side_effect: Exception | None = None,
+) -> object:
+    @contextlib.asynccontextmanager
+    async def _ctx(*args: object, **kwargs: object) -> AsyncGenerator[AsyncMock]:
+        mock_client = AsyncMock()
+        if health_side_effect is not None:
+            mock_client.health = AsyncMock(side_effect=health_side_effect)
+        else:
+            mock_client.health = AsyncMock(return_value=health_return)
+        yield mock_client
+
+    return _ctx
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/integrations/prowlarr
+# ---------------------------------------------------------------------------
+
+
+async def test_get_returns_null_when_not_configured(api_client: httpx.AsyncClient) -> None:
+    response = await api_client.get("/api/v1/integrations/prowlarr")
+    assert response.status_code == 200
+    assert response.json() is None
+
+
+async def test_get_returns_config_after_put(api_client: httpx.AsyncClient) -> None:
+    await api_client.put("/api/v1/integrations/prowlarr", json=_VALID_PAYLOAD)
+
+    response = await api_client.get("/api/v1/integrations/prowlarr")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["base_url"] == "http://localhost:9696"
+    assert "api_key" not in data
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/v1/integrations/prowlarr
+# ---------------------------------------------------------------------------
+
+
+async def test_put_creates_config(api_client: httpx.AsyncClient) -> None:
+    response = await api_client.put("/api/v1/integrations/prowlarr", json=_VALID_PAYLOAD)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Local Prowlarr"
+    assert data["base_url"] == "http://localhost:9696"
+    assert "api_key" not in data
+
+
+async def test_put_replaces_existing_config(api_client: httpx.AsyncClient) -> None:
+    await api_client.put("/api/v1/integrations/prowlarr", json=_VALID_PAYLOAD)
+
+    updated = {**_VALID_PAYLOAD, "base_url": "http://192.168.1.10:9696", "name": "Updated"}
+    response = await api_client.put("/api/v1/integrations/prowlarr", json=updated)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["base_url"] == "http://192.168.1.10:9696"
+    assert data["name"] == "Updated"
+
+
+async def test_put_returns_422_for_missing_required_field(api_client: httpx.AsyncClient) -> None:
+    bad = {"name": "Prowlarr", "base_url": "http://localhost:9696"}  # api_key missing
+    response = await api_client.put("/api/v1/integrations/prowlarr", json=bad)
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/integrations/prowlarr
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_returns_204(api_client: httpx.AsyncClient) -> None:
+    await api_client.put("/api/v1/integrations/prowlarr", json=_VALID_PAYLOAD)
+    response = await api_client.delete("/api/v1/integrations/prowlarr")
+    assert response.status_code == 204
+
+
+async def test_delete_returns_404_when_not_configured(api_client: httpx.AsyncClient) -> None:
+    response = await api_client.delete("/api/v1/integrations/prowlarr")
+    assert response.status_code == 404
+
+
+async def test_delete_then_get_returns_null(api_client: httpx.AsyncClient) -> None:
+    await api_client.put("/api/v1/integrations/prowlarr", json=_VALID_PAYLOAD)
+    await api_client.delete("/api/v1/integrations/prowlarr")
+
+    response = await api_client.get("/api/v1/integrations/prowlarr")
+    assert response.status_code == 200
+    assert response.json() is None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/integrations/prowlarr/test
+# ---------------------------------------------------------------------------
+
+
+async def test_test_endpoint_success(api_client: httpx.AsyncClient) -> None:
+    mock_factory = make_mock_build_client(
+        health_return=ProwlarrHealth(version="1.5.0", app_name="Prowlarr")
+    )
+    with patch("app.services.prowlarr_service._build_client", mock_factory):
+        response = await api_client.post(
+            "/api/v1/integrations/prowlarr/test", json=_TEST_PAYLOAD
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["version"] == "1.5.0"
+
+
+async def test_test_endpoint_auth_failure(api_client: httpx.AsyncClient) -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=ProwlarrAuthError("invalid api key")
+    )
+    with patch("app.services.prowlarr_service._build_client", mock_factory):
+        response = await api_client.post(
+            "/api/v1/integrations/prowlarr/test", json=_TEST_PAYLOAD
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert data["error"] == "invalid API key"
+
+
+async def test_test_endpoint_timeout(api_client: httpx.AsyncClient) -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=ProwlarrTimeoutError("timed out")
+    )
+    with patch("app.services.prowlarr_service._build_client", mock_factory):
+        response = await api_client.post(
+            "/api/v1/integrations/prowlarr/test", json=_TEST_PAYLOAD
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert data["error"] == "connection timeout"
+
+
+async def test_test_endpoint_generic_error(api_client: httpx.AsyncClient) -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=ProwlarrServerError(status_code=500, message="internal error")
+    )
+    with patch("app.services.prowlarr_service._build_client", mock_factory):
+        response = await api_client.post(
+            "/api/v1/integrations/prowlarr/test", json=_TEST_PAYLOAD
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert "500" in data["error"]

--- a/tests/integration/test_prowlarr_settings_service.py
+++ b/tests/integration/test_prowlarr_settings_service.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.exceptions import (
+    ProwlarrAuthError,
+    ProwlarrServerError,
+    ProwlarrTimeoutError,
+)
+from app.schemas.prowlarr import ProwlarrConfigIn, ProwlarrHealth, ProwlarrTestResult
+from app.services import prowlarr_service as svc
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CONFIG_IN = ProwlarrConfigIn(
+    name="Local Prowlarr",
+    base_url="http://localhost:9696",
+    api_key="abc123",
+    enabled=True,
+)
+
+
+def make_mock_build_client(
+    health_return: ProwlarrHealth | None = None,
+    health_side_effect: Exception | None = None,
+) -> object:
+    @contextlib.asynccontextmanager
+    async def _ctx(*args: object, **kwargs: object) -> AsyncGenerator[AsyncMock]:
+        mock_client = AsyncMock()
+        if health_side_effect is not None:
+            mock_client.health = AsyncMock(side_effect=health_side_effect)
+        else:
+            mock_client.health = AsyncMock(return_value=health_return)
+        yield mock_client
+
+    return _ctx
+
+
+# ---------------------------------------------------------------------------
+# CRUD — upsert / get / delete
+# ---------------------------------------------------------------------------
+
+
+async def test_upsert_creates_new_config(db_session: AsyncSession) -> None:
+    result = await svc.upsert_config(db_session, _CONFIG_IN)
+
+    assert result.name == "Local Prowlarr"
+    assert result.base_url == "http://localhost:9696"
+    assert result.enabled is True
+    assert not hasattr(result, "api_key")
+
+
+async def test_upsert_replaces_existing_config(db_session: AsyncSession) -> None:
+    await svc.upsert_config(db_session, _CONFIG_IN)
+
+    updated = ProwlarrConfigIn(
+        name="Updated Prowlarr",
+        base_url="http://192.168.1.10:9696",
+        api_key="newkey",
+        enabled=False,
+    )
+    result = await svc.upsert_config(db_session, updated)
+
+    assert result.name == "Updated Prowlarr"
+    assert result.base_url == "http://192.168.1.10:9696"
+    assert result.enabled is False
+
+    # Only one row in DB
+    second_get = await svc.get_config(db_session)
+    assert second_get is not None
+    assert second_get.base_url == "http://192.168.1.10:9696"
+
+
+async def test_get_returns_decrypted_config_without_api_key(db_session: AsyncSession) -> None:
+    await svc.upsert_config(db_session, _CONFIG_IN)
+
+    result = await svc.get_config(db_session)
+
+    assert result is not None
+    assert result.base_url == "http://localhost:9696"
+    assert not hasattr(result, "api_key")
+
+
+async def test_get_returns_none_when_not_configured(db_session: AsyncSession) -> None:
+    result = await svc.get_config(db_session)
+    assert result is None
+
+
+async def test_delete_returns_true_when_exists(db_session: AsyncSession) -> None:
+    await svc.upsert_config(db_session, _CONFIG_IN)
+    assert await svc.delete_config(db_session) is True
+
+
+async def test_delete_returns_false_when_not_configured(db_session: AsyncSession) -> None:
+    assert await svc.delete_config(db_session) is False
+
+
+# ---------------------------------------------------------------------------
+# test_connection — mock _build_client
+# ---------------------------------------------------------------------------
+
+
+async def test_test_connection_success() -> None:
+    mock_factory = make_mock_build_client(
+        health_return=ProwlarrHealth(version="1.5.0", app_name="Prowlarr")
+    )
+    with patch("app.services.prowlarr_service._build_client", mock_factory):
+        result = await svc.test_connection("http://localhost:9696", "abc123")
+
+    assert result == ProwlarrTestResult(ok=True, version="1.5.0")
+
+
+async def test_test_connection_auth_failure() -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=ProwlarrAuthError("invalid api key")
+    )
+    with patch("app.services.prowlarr_service._build_client", mock_factory):
+        result = await svc.test_connection("http://localhost:9696", "wrongkey")
+
+    assert result == ProwlarrTestResult(ok=False, error="invalid API key")
+
+
+async def test_test_connection_timeout() -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=ProwlarrTimeoutError("timed out")
+    )
+    with patch("app.services.prowlarr_service._build_client", mock_factory):
+        result = await svc.test_connection("http://localhost:9696", "abc123")
+
+    assert result == ProwlarrTestResult(ok=False, error="connection timeout")
+
+
+async def test_test_connection_generic_error() -> None:
+    mock_factory = make_mock_build_client(
+        health_side_effect=ProwlarrServerError(status_code=500, message="internal error")
+    )
+    with patch("app.services.prowlarr_service._build_client", mock_factory):
+        result = await svc.test_connection("http://localhost:9696", "abc123")
+
+    assert result.ok is False
+    assert result.error is not None
+    assert "500" in result.error


### PR DESCRIPTION
Adds CRUD + test endpoints for Prowlarr integration config, mirroring the qBittorrent settings pattern exactly.

## What changed

- `feat(integrations): add prowlarr settings request/response schemas` — `3dc9a77`
- `feat(services): add prowlarr settings service` — `9c6a61a`
- `feat(api): add prowlarr integration endpoints` — `cb02ce0`
- `test(integrations): add prowlarr settings service and api tests` — `160e06b`

## Endpoints

- `GET /api/v1/integrations/prowlarr` — current config (api_key not exposed)
- `PUT /api/v1/integrations/prowlarr` — upsert config
- `DELETE /api/v1/integrations/prowlarr` — remove config (404 if none)
- `POST /api/v1/integrations/prowlarr/test` — stateless connection test against `/api/v1/system/status`, always returns 200 with `{ok, version, error}`

## What did NOT change

- No migration — `integration_configs` table and `prowlarr` enum value already exist (initial migration `0001`)
- No new exception classes — all Prowlarr exceptions already exist in `app/integrations/exceptions.py`
- No model changes — reuses `IntegrationConfig`
- `ProwlarrClient` (`app/integrations/prowlarr/client.py`) reused as-is; `health()` powers the test endpoint
- `encrypt_config` / `decrypt_config` (`app/core/crypto.py`) reused without modification

## Tests

- 22 new tests (10 service + 12 API)
- Coverage: CRUD happy path, `test_connection` for success / auth failure / timeout / generic 500, 422 validation, 404 on empty delete
- Full suite: 142 passing, no regressions

## Out of scope

- Search flow → 3.2
- Release scoring → 3.3
- Grab orchestration → 3.4
- Frontend (settings UI + book search/grab) → 3.5

## Known tech debt (not addressed here)

- `last_test_at` / `last_test_ok` fields exist on `IntegrationConfig` and are exposed in `ProwlarrConfigOut`, but `update_test_result()` is never called — same behavior as qBittorrent. Both integrations should wire this up in a future cleanup pass.

## How to test locally

1. Set `LIBRARR_SECRET_KEY` in env
2. `PUT /api/v1/integrations/prowlarr` with `{name, base_url, api_key, enabled}`
3. `POST /api/v1/integrations/prowlarr/test` with `{base_url, api_key}` — should return `{ok: true, version: "1.x.x", error: null}` against a live Prowlarr