### PR TITLE
feat(integrations): add prowlarr release search

### DIFF
--- a/app/api/v1/book.py
+++ b/app/api/v1/book.py
@@ -10,6 +10,7 @@ from app.core.db import get_db
 from app.core.deps import get_metadata_service, get_prowlarr_client
 from app.integrations.exceptions import (
     ProwlarrAuthError,
+    ProwlarrNotConfiguredError,
     ProwlarrRateLimitError,
     ProwlarrServerError,
     ProwlarrTimeoutError,
@@ -27,6 +28,8 @@ from app.schemas.book import (
 )
 from app.schemas.common import PaginatedResponse
 from app.schemas.prowlarr import ProwlarrRelease
+from app.schemas.release import ReleaseSearchResponse
+from app.services import release_search_service
 from app.services.book_service import BookService
 from app.services.metadata import MetadataService
 
@@ -133,7 +136,7 @@ async def delete_book(
 
 
 @router.post("/{book_id}/search", response_model=list[ProwlarrRelease])
-async def search_book_releases(
+async def search_book_releases_legacy(
     book_id: uuid.UUID,
     svc: Annotated[BookService, Depends(_book_service)],
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -145,6 +148,32 @@ async def search_book_releases(
         raise HTTPException(status_code=502, detail="Prowlarr authentication failed")
     except ProwlarrTimeoutError:
         raise HTTPException(status_code=503, detail="Prowlarr unreachable")
+    except ProwlarrServerError as exc:
+        raise HTTPException(status_code=502, detail=f"Prowlarr error: {str(exc)[:100]}")
+    except ProwlarrRateLimitError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail="Prowlarr rate limited",
+            headers={"Retry-After": str(exc.retry_after or 60)},
+        )
+
+
+@router.post("/{book_id}/release-search", response_model=ReleaseSearchResponse)
+async def search_book_releases(
+    book_id: uuid.UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ReleaseSearchResponse:
+    try:
+        return await release_search_service.search_releases(db, book_id)
+    except ProwlarrNotConfiguredError:
+        raise HTTPException(
+            status_code=412,
+            detail="Prowlarr is not configured. Configure it in integration settings.",
+        )
+    except ProwlarrAuthError:
+        raise HTTPException(status_code=502, detail="Prowlarr authentication failed")
+    except ProwlarrTimeoutError:
+        raise HTTPException(status_code=504, detail="Prowlarr request timed out")
     except ProwlarrServerError as exc:
         raise HTTPException(status_code=502, detail=f"Prowlarr error: {str(exc)[:100]}")
     except ProwlarrRateLimitError as exc:

--- a/app/integrations/exceptions.py
+++ b/app/integrations/exceptions.py
@@ -97,6 +97,10 @@ class ProwlarrTimeoutError(ProwlarrError):
     """Timeout connecting to or reading from Prowlarr."""
 
 
+class ProwlarrNotConfiguredError(ProwlarrError):
+    """Prowlarr is not configured or has been disabled."""
+
+
 class QBittorrentError(IntegrationError):
     """Base for qBittorrent errors."""
 

--- a/app/schemas/release.py
+++ b/app/schemas/release.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ReleaseResult(BaseModel):
+    guid: str
+    title: str
+    indexer: str
+    size_bytes: int
+    seeders: int
+    leechers: int
+    publish_date: datetime | None
+    download_url: str | None
+    protocol: Literal["torrent"]
+    detected_format: Literal["epub", "pdf", "mobi", "azw3", "unknown"]
+    score: int
+
+
+class ReleaseSearchResponse(BaseModel):
+    query: str
+    results: list[ReleaseResult]
+    total: int

--- a/app/services/prowlarr_service.py
+++ b/app/services/prowlarr_service.py
@@ -12,6 +12,7 @@ from app.core.crypto import decrypt_config, encrypt_config
 from app.integrations.exceptions import (
     ProwlarrAuthError,
     ProwlarrError,
+    ProwlarrNotConfiguredError,
     ProwlarrTimeoutError,
 )
 from app.integrations.prowlarr.client import ProwlarrClient
@@ -64,6 +65,23 @@ def _row_to_out(row: object, cfg: dict[str, Any]) -> ProwlarrConfigOut:
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
+
+
+@contextlib.asynccontextmanager
+async def get_active_client(session: AsyncSession) -> AsyncGenerator[ProwlarrClient]:
+    """Yield a ProwlarrClient built from the persisted DB config.
+
+    Raises ProwlarrNotConfiguredError if no enabled config exists.
+    Credential resolution diverges from test_connection here; httpx construction
+    is identical — both delegate to _build_client.
+    """
+    repo = IntegrationConfigRepository(session)
+    row = await repo.get_by_type(_TYPE)
+    if row is None or not row.enabled:
+        raise ProwlarrNotConfiguredError("Prowlarr is not configured or is disabled")
+    cfg = decrypt_config(row.config)
+    async with _build_client(cfg["base_url"], cfg["api_key"]) as client:
+        yield client
 
 
 async def get_config(session: AsyncSession) -> ProwlarrConfigOut | None:

--- a/app/services/release_scoring.py
+++ b/app/services/release_scoring.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Literal
+
+_FORMAT_RE = re.compile(r"\b(epub|pdf|mobi|azw3)\b", re.IGNORECASE)
+_FORMAT_SCORES: dict[str, int] = {"epub": 100, "azw3": 70, "pdf": 60, "mobi": 40}
+_SIZE_PENALTY_THRESHOLD_MB = 100
+_AGE_THRESHOLD_DAYS = 365
+
+DetectedFormat = Literal["epub", "pdf", "mobi", "azw3", "unknown"]
+
+
+def score_release(
+    title: str,
+    seeders: int,
+    size_bytes: int,
+    publish_date: datetime | None,
+    now: datetime | None = None,
+) -> tuple[DetectedFormat, int]:
+    """Return (detected_format, score) for a release candidate.
+
+    Pure function — no I/O. Pass `now` in tests to avoid time-dependent results.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    m = _FORMAT_RE.search(title)
+    detected: DetectedFormat = m.group(1).lower() if m else "unknown"  # type: ignore[assignment]
+    format_score = _FORMAT_SCORES.get(detected, 0)
+
+    seeder_score = min(seeders, 50) * 2
+
+    size_mb = size_bytes / (1024 * 1024)
+    size_penalty = (size_mb - _SIZE_PENALTY_THRESHOLD_MB) * 0.5 if size_mb > _SIZE_PENALTY_THRESHOLD_MB else 0.0
+
+    age_penalty = 0
+    if publish_date is not None:
+        pd = publish_date if publish_date.tzinfo else publish_date.replace(tzinfo=timezone.utc)
+        n = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
+        if (n - pd).days > _AGE_THRESHOLD_DAYS:
+            age_penalty = 10
+
+    return detected, round(format_score + seeder_score - size_penalty - age_penalty)

--- a/app/services/release_search_service.py
+++ b/app/services/release_search_service.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import BookNotFoundError
+from app.repositories.book import BookRepository
+from app.schemas.release import ReleaseResult, ReleaseSearchResponse
+from app.services import prowlarr_service
+from app.services.release_scoring import score_release
+
+_SEARCH_LIMIT = 100
+_RESULT_CAP = 50
+_MIN_SEEDERS = 1
+_MIN_SIZE_BYTES = 100 * 1024  # 100 KB
+
+
+async def search_releases(session: AsyncSession, book_id: uuid.UUID) -> ReleaseSearchResponse:
+    books = BookRepository(session)
+    book = await books.get(book_id)
+    if book is None:
+        raise BookNotFoundError(str(book_id))
+
+    author_rows = await books.get_authors_for_book(book_id)
+    primary_name = author_rows[0].author.canonical_name if author_rows else ""
+    query = f"{book.title} {primary_name}".strip()
+
+    async with prowlarr_service.get_active_client(session) as client:
+        raw_releases = await client.search(query=query, limit=_SEARCH_LIMIT)
+
+    results: list[ReleaseResult] = []
+    for r in raw_releases:
+        seeders = r.seeders or 0
+        if seeders < _MIN_SEEDERS:
+            continue
+        if r.size_bytes < _MIN_SIZE_BYTES:
+            continue
+        if r.protocol != "torrent":
+            continue
+
+        detected_format, final_score = score_release(
+            title=r.title,
+            seeders=seeders,
+            size_bytes=r.size_bytes,
+            publish_date=r.publish_date,
+        )
+
+        results.append(
+            ReleaseResult(
+                guid=r.guid,
+                title=r.title,
+                indexer=r.indexer_name,
+                size_bytes=r.size_bytes,
+                seeders=seeders,
+                leechers=r.leechers or 0,
+                publish_date=r.publish_date,
+                download_url=r.download_url,
+                protocol="torrent",
+                detected_format=detected_format,
+                score=final_score,
+            )
+        )
+
+    results.sort(key=lambda x: x.score, reverse=True)
+    capped = results[:_RESULT_CAP]
+
+    return ReleaseSearchResponse(query=query, results=capped, total=len(capped))

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -31,6 +31,7 @@ Intentional technical debts and deferred work. Each item must be resolved before
 ## API design
 
 - **API path naming review pre-1.0** — `GET /api/v1/author/{id}/book` uses singular sub-resource naming (matching *arr convention) while the top-level collection is `/api/v1/book` (also singular). The inconsistency is minor but worth a sweep of all sub-resource paths before the 1.0 public API freeze to confirm they follow the same convention throughout.
+- **Remove settings-based `POST /api/v1/book/{book_id}/search`** (`app/api/v1/book.py`, `app/services/book_service.py:search_releases`) — this endpoint uses `settings.prowlarr_url`/`settings.prowlarr_api_key` env vars instead of the DB-persisted `IntegrationConfig`. It predates the `IntegrationConfig` store. Remove before the frontend wires up the new `POST /api/v1/book/{book_id}/release-search` endpoint, which is the correct replacement.
 
 ## Testing
 

--- a/tests/integration/test_release_search_api.py
+++ b/tests/integration/test_release_search_api.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.core.exceptions import BookNotFoundError
+from app.integrations.exceptions import (
+    ProwlarrAuthError,
+    ProwlarrNotConfiguredError,
+    ProwlarrServerError,
+    ProwlarrTimeoutError,
+)
+from app.schemas.release import ReleaseResult, ReleaseSearchResponse
+
+_BOOK_ID = "00000000-0000-0000-0000-000000000001"
+
+_HAPPY_RESPONSE = ReleaseSearchResponse(
+    query="Test Book Test Author",
+    results=[
+        ReleaseResult(
+            guid="abc123",
+            title="Test Book.epub",
+            indexer="MyIndexer",
+            size_bytes=5_000_000,
+            seeders=10,
+            leechers=2,
+            publish_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            download_url="https://example.com/dl",
+            protocol="torrent",
+            detected_format="epub",
+            score=120,
+        )
+    ],
+    total=1,
+)
+
+_PATCH_TARGET = "app.api.v1.book.release_search_service.search_releases"
+
+
+# ---------------------------------------------------------------------------
+# 200 — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_200_happy_path(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(return_value=_HAPPY_RESPONSE)):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/release-search")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["query"] == "Test Book Test Author"
+    assert body["results"][0]["detected_format"] == "epub"
+    assert body["results"][0]["protocol"] == "torrent"
+    assert "magnet_url" not in body["results"][0]
+
+
+# ---------------------------------------------------------------------------
+# 404 — book not found
+# ---------------------------------------------------------------------------
+
+
+async def test_404_book_not_found(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(side_effect=BookNotFoundError(_BOOK_ID))):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/release-search")
+
+    assert r.status_code == 404
+    assert r.json()["details"]["book_id"] == _BOOK_ID
+
+
+# ---------------------------------------------------------------------------
+# 412 — Prowlarr not configured
+# ---------------------------------------------------------------------------
+
+
+async def test_412_prowlarr_not_configured(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(side_effect=ProwlarrNotConfiguredError("not configured"))):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/release-search")
+
+    assert r.status_code == 412
+    assert "Prowlarr is not configured" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 502 — Prowlarr auth error
+# ---------------------------------------------------------------------------
+
+
+async def test_502_auth_error(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(side_effect=ProwlarrAuthError("bad key"))):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/release-search")
+
+    assert r.status_code == 502
+    assert "authentication" in r.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 504 — Prowlarr timeout
+# ---------------------------------------------------------------------------
+
+
+async def test_504_timeout(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(side_effect=ProwlarrTimeoutError("timed out"))):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/release-search")
+
+    assert r.status_code == 504
+
+
+# ---------------------------------------------------------------------------
+# 502 — Prowlarr server error
+# ---------------------------------------------------------------------------
+
+
+async def test_502_server_error(api_client: httpx.AsyncClient) -> None:
+    with patch(
+        _PATCH_TARGET,
+        AsyncMock(side_effect=ProwlarrServerError(status_code=500, message="internal error")),
+    ):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/release-search")
+
+    assert r.status_code == 502

--- a/tests/services/test_release_scoring.py
+++ b/tests/services/test_release_scoring.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.services.release_scoring import score_release
+
+_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+
+def test_epub_format_detected() -> None:
+    detected, _ = score_release("Great Book EPUB", 0, 1_000_000, None, now=_NOW)
+    assert detected == "epub"
+
+
+def test_azw3_format_detected() -> None:
+    detected, _ = score_release("Great Book AZW3", 0, 1_000_000, None, now=_NOW)
+    assert detected == "azw3"
+
+
+def test_pdf_format_detected() -> None:
+    detected, _ = score_release("Great Book.pdf", 0, 1_000_000, None, now=_NOW)
+    assert detected == "pdf"
+
+
+def test_mobi_format_detected() -> None:
+    detected, _ = score_release("Great Book.mobi", 0, 1_000_000, None, now=_NOW)
+    assert detected == "mobi"
+
+
+def test_unknown_format_when_no_match() -> None:
+    detected, _ = score_release("Great Book", 0, 1_000_000, None, now=_NOW)
+    assert detected == "unknown"
+
+
+def test_format_detection_is_case_insensitive() -> None:
+    d1, _ = score_release("Book EPUB", 0, 0, None, now=_NOW)
+    d2, _ = score_release("Book epub", 0, 0, None, now=_NOW)
+    d3, _ = score_release("Book Epub", 0, 0, None, now=_NOW)
+    assert d1 == d2 == d3 == "epub"
+
+
+# ---------------------------------------------------------------------------
+# Format score component
+# ---------------------------------------------------------------------------
+
+
+def test_epub_scores_100() -> None:
+    # epub=100, seeders=0, size<100MB, no date → 100+0-0-0=100
+    _, s = score_release("epub", 0, 1_000_000, None, now=_NOW)
+    assert s == 100
+
+
+def test_azw3_scores_70() -> None:
+    _, s = score_release("azw3", 0, 1_000_000, None, now=_NOW)
+    assert s == 70
+
+
+def test_pdf_scores_60() -> None:
+    _, s = score_release("pdf", 0, 1_000_000, None, now=_NOW)
+    assert s == 60
+
+
+def test_mobi_scores_40() -> None:
+    _, s = score_release("mobi", 0, 1_000_000, None, now=_NOW)
+    assert s == 40
+
+
+def test_unknown_format_scores_0() -> None:
+    _, s = score_release("no format", 0, 1_000_000, None, now=_NOW)
+    assert s == 0
+
+
+# ---------------------------------------------------------------------------
+# Seeder score component
+# ---------------------------------------------------------------------------
+
+
+def test_seeder_score_below_cap() -> None:
+    # 10 seeders → min(10,50)*2 = 20; with epub format_score=100 → 120
+    _, s = score_release("epub", 10, 1_000_000, None, now=_NOW)
+    assert s == 120
+
+
+def test_seeder_cap_at_50() -> None:
+    # min(50,50)*2 = 100; epub 100 → 200
+    _, s = score_release("epub", 50, 1_000_000, None, now=_NOW)
+    assert s == 200
+
+
+def test_seeder_above_cap_clamped_to_50() -> None:
+    # min(51,50)*2 = 100 — same as exactly 50
+    _, s1 = score_release("epub", 50, 1_000_000, None, now=_NOW)
+    _, s2 = score_release("epub", 51, 1_000_000, None, now=_NOW)
+    assert s1 == s2
+
+
+def test_zero_seeders() -> None:
+    _, s = score_release("epub", 0, 1_000_000, None, now=_NOW)
+    assert s == 100  # only format_score
+
+
+# ---------------------------------------------------------------------------
+# Size penalty component
+# ---------------------------------------------------------------------------
+
+
+def test_exactly_100mb_no_penalty() -> None:
+    _, s = score_release("epub", 0, 100 * 1024 * 1024, None, now=_NOW)
+    assert s == 100
+
+
+def test_200mb_penalty_50() -> None:
+    # (200-100)*0.5 = 50; epub 100 - 50 = 50
+    _, s = score_release("epub", 0, 200 * 1024 * 1024, None, now=_NOW)
+    assert s == 50
+
+
+def test_300mb_penalty_100() -> None:
+    # (300-100)*0.5 = 100; epub 100 - 100 = 0
+    _, s = score_release("epub", 0, 300 * 1024 * 1024, None, now=_NOW)
+    assert s == 0
+
+
+def test_below_100mb_no_penalty() -> None:
+    _, s1 = score_release("epub", 0, 50 * 1024 * 1024, None, now=_NOW)
+    _, s2 = score_release("epub", 0, 1_000_000, None, now=_NOW)
+    assert s1 == s2 == 100
+
+
+# ---------------------------------------------------------------------------
+# Age penalty component
+# ---------------------------------------------------------------------------
+
+
+def test_364_days_no_penalty() -> None:
+    pd = _NOW - timedelta(days=364)
+    _, s = score_release("epub", 0, 1_000_000, pd, now=_NOW)
+    assert s == 100
+
+
+def test_exactly_365_days_no_penalty() -> None:
+    # boundary: >365 triggers penalty, so exactly 365 does NOT
+    pd = _NOW - timedelta(days=365)
+    _, s = score_release("epub", 0, 1_000_000, pd, now=_NOW)
+    assert s == 100
+
+
+def test_366_days_penalty_10() -> None:
+    pd = _NOW - timedelta(days=366)
+    _, s = score_release("epub", 0, 1_000_000, pd, now=_NOW)
+    assert s == 90
+
+
+def test_no_publish_date_no_penalty() -> None:
+    _, s = score_release("epub", 0, 1_000_000, None, now=_NOW)
+    assert s == 100
+
+
+def test_naive_publish_date_treated_as_utc() -> None:
+    pd_naive = datetime(2024, 12, 1)  # naive
+    pd_aware = datetime(2024, 12, 1, tzinfo=timezone.utc)
+    _, s_naive = score_release("epub", 0, 1_000_000, pd_naive, now=_NOW)
+    _, s_aware = score_release("epub", 0, 1_000_000, pd_aware, now=_NOW)
+    assert s_naive == s_aware

--- a/tests/services/test_release_search_service.py
+++ b/tests/services/test_release_search_service.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import contextlib
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import BookNotFoundError
+from app.integrations.exceptions import ProwlarrAuthError, ProwlarrNotConfiguredError
+from app.integrations.prowlarr.client import ProwlarrClient
+from app.models.associations import book_authors_table
+from app.models.author import Author
+from app.models.book import Book
+from app.schemas.prowlarr import ProwlarrRelease
+from app.services.release_search_service import search_releases
+
+_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+_BASE_RELEASE = ProwlarrRelease(
+    guid="r1",
+    title="Great Book EPUB",
+    indexer_name="MyIndexer",
+    size_bytes=5_000_000,
+    publish_date=_NOW,
+    download_url="https://example.com/dl",
+    info_url=None,
+    seeders=10,
+    leechers=2,
+    protocol="torrent",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _insert_book(
+    session: AsyncSession,
+    title: str,
+    author_name: str | None = "Jane Doe",
+) -> Book:
+    book = Book(title=title, status="wanted", system_confidence=0.8)
+    session.add(book)
+    await session.flush()
+
+    if author_name is not None:
+        author = Author(canonical_name=author_name, sort_name=author_name, system_confidence=0.8)
+        session.add(author)
+        await session.flush()
+        await session.execute(
+            book_authors_table.insert().values(
+                book_id=book.id,
+                author_id=author.id,
+                role="primary",
+                position=1,
+            )
+        )
+        await session.flush()
+
+    return book
+
+
+def _make_active_client_ctx(mock_client: ProwlarrClient) -> object:
+    @contextlib.asynccontextmanager
+    async def _ctx(session: AsyncSession) -> AsyncGenerator[ProwlarrClient]:
+        yield mock_client
+
+    return _ctx
+
+
+def _make_raises_ctx(exc: Exception) -> object:
+    @contextlib.asynccontextmanager
+    async def _ctx(session: AsyncSession) -> AsyncGenerator[None]:
+        raise exc
+        yield  # type: ignore[misc]
+
+    return _ctx
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_returns_scored_results(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Great Book", "Jane Doe")
+    mock_client = AsyncMock()
+    mock_client.search = AsyncMock(return_value=[_BASE_RELEASE])
+
+    with patch("app.services.prowlarr_service.get_active_client", _make_active_client_ctx(mock_client)):
+        result = await search_releases(db_session, book.id)
+
+    assert result.query == "Great Book Jane Doe"
+    assert result.total == 1
+    assert result.results[0].title == "Great Book EPUB"
+    assert result.results[0].detected_format == "epub"
+    assert result.results[0].indexer == "MyIndexer"
+    assert result.results[0].protocol == "torrent"
+
+
+async def test_query_uses_title_only_when_no_author(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Orphan Book", author_name=None)
+    mock_client = AsyncMock()
+    mock_client.search = AsyncMock(return_value=[])
+
+    with patch("app.services.prowlarr_service.get_active_client", _make_active_client_ctx(mock_client)):
+        result = await search_releases(db_session, book.id)
+
+    assert result.query == "Orphan Book"
+    mock_client.search.assert_awaited_once_with(query="Orphan Book", limit=100)
+
+
+async def test_search_called_with_limit_100(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Book", "Author")
+    mock_client = AsyncMock()
+    mock_client.search = AsyncMock(return_value=[])
+
+    with patch("app.services.prowlarr_service.get_active_client", _make_active_client_ctx(mock_client)):
+        await search_releases(db_session, book.id)
+
+    mock_client.search.assert_awaited_once_with(query="Book Author", limit=100)
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+async def test_zero_seeder_release_filtered(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Book", "Author")
+    zero_seed = _BASE_RELEASE.model_copy(update={"guid": "r_zero", "seeders": 0})
+    mock_client = AsyncMock()
+    mock_client.search = AsyncMock(return_value=[zero_seed])
+
+    with patch("app.services.prowlarr_service.get_active_client", _make_active_client_ctx(mock_client)):
+        result = await search_releases(db_session, book.id)
+
+    assert result.total == 0
+
+
+async def test_small_release_filtered(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Book", "Author")
+    tiny = _BASE_RELEASE.model_copy(update={"guid": "r_tiny", "size_bytes": 1024})
+    mock_client = AsyncMock()
+    mock_client.search = AsyncMock(return_value=[tiny])
+
+    with patch("app.services.prowlarr_service.get_active_client", _make_active_client_ctx(mock_client)):
+        result = await search_releases(db_session, book.id)
+
+    assert result.total == 0
+
+
+async def test_usenet_release_filtered(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Book", "Author")
+    usenet = _BASE_RELEASE.model_copy(update={"guid": "r_usenet", "protocol": "usenet"})
+    mock_client = AsyncMock()
+    mock_client.search = AsyncMock(return_value=[usenet])
+
+    with patch("app.services.prowlarr_service.get_active_client", _make_active_client_ctx(mock_client)):
+        result = await search_releases(db_session, book.id)
+
+    assert result.total == 0
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+async def test_results_ordered_by_score_descending(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Book", "Author")
+    low = _BASE_RELEASE.model_copy(update={"guid": "r_low", "seeders": 1})
+    high = _BASE_RELEASE.model_copy(update={"guid": "r_high", "seeders": 50})
+    mock_client = AsyncMock()
+    mock_client.search = AsyncMock(return_value=[low, high])
+
+    with patch("app.services.prowlarr_service.get_active_client", _make_active_client_ctx(mock_client)):
+        result = await search_releases(db_session, book.id)
+
+    assert result.total == 2
+    assert result.results[0].guid == "r_high"
+    assert result.results[0].score > result.results[1].score
+
+
+# ---------------------------------------------------------------------------
+# Empty results
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_results_returned(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Book", "Author")
+    mock_client = AsyncMock()
+    mock_client.search = AsyncMock(return_value=[])
+
+    with patch("app.services.prowlarr_service.get_active_client", _make_active_client_ctx(mock_client)):
+        result = await search_releases(db_session, book.id)
+
+    assert result.total == 0
+    assert result.results == []
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+async def test_book_not_found_raises(db_session: AsyncSession) -> None:
+    with pytest.raises(BookNotFoundError):
+        await search_releases(db_session, uuid.uuid4())
+
+
+async def test_unconfigured_raises(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Book", "Author")
+
+    with patch(
+        "app.services.prowlarr_service.get_active_client",
+        _make_raises_ctx(ProwlarrNotConfiguredError("not configured")),
+    ):
+        with pytest.raises(ProwlarrNotConfiguredError):
+            await search_releases(db_session, book.id)
+
+
+async def test_auth_error_propagates(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session, "Book", "Author")
+    mock_client = AsyncMock()
+    mock_client.search = AsyncMock(side_effect=ProwlarrAuthError("bad key"))
+
+    with patch("app.services.prowlarr_service.get_active_client", _make_active_client_ctx(mock_client)):
+        with pytest.raises(ProwlarrAuthError):
+            await search_releases(db_session, book.id)


### PR DESCRIPTION
Adds a new endpoint that searches Prowlarr for torrent releases of an existing book in the library.

## What changed

- `feat(integrations): add ProwlarrNotConfiguredError and prowlarr_service.get_active_client` — `220d8fc`
- `feat(schemas): add release search response schemas` — `7e72bd3`
- `feat(services): add release scoring and release search service` — `478e42a`
- `feat(api): add release-search endpoint to book router` — `fe409da`
- `test(services): add release scoring and search service tests` — `1f8b371`
- `test(integration): add release-search api endpoint tests` — `6dc6485`

## Endpoint

`POST /api/v1/book/{book_id}/release-search`

- Loads the book with eager-loaded authors
- Builds query: `f"{title} {primary_author.canonical_name}".strip()`
- Reads active Prowlarr config from the encrypted DB store (not env vars)
- Queries Prowlarr with `limit=100`
- Hard-filters: `seeders >= 1`, `size > 100KB`, `protocol == "torrent"`
- Scores each release (format + seeders − size penalty − age penalty)
- Returns top 50 sorted by score desc

## Scoring

Deterministic, hardcoded — pure function in `app/services/release_scoring.py`:

- Format: epub=100, azw3=70, pdf=60, mobi=40, unknown=0 (regex match on title)
- Seeders: `min(seeders, 50) * 2` (cap 100)
- Size penalty: `(size_mb − 100) * 0.5` for releases over 100MB
- Age penalty: 10 points if older than 365 days

## Error mapping

- 404 — book not found
- 412 — Prowlarr not configured or disabled
- 502 — Prowlarr auth or server error
- 504 — Prowlarr timeout
- 429 — Prowlarr rate limited (with `Retry-After` header)

## Out of scope

- Author resolution beyond `book.authors[0]` — multi-author query weighting comes later
- Quality profiles — hardcoded scoring is intentional for v0.1
- Audiobook category (3030/7050) — ebook only (`limit=100` covers a wide net since client doesn't yet accept categories)
- Indexer filtering — all enabled indexers queried
- Grab orchestration → 3.4
- Frontend → 3.5

## Tech debt acknowledged

- Existing `POST /api/v1/book/{book_id}/search` endpoint (now renamed to `search_book_releases_legacy` in code, path unchanged) uses env-var settings instead of the DB-persisted IntegrationConfig. Tracked in `docs/FOLLOWUPS.md` for removal before frontend wires up the new endpoint.
- `ProwlarrClient.search()` does not yet accept a `categories` param — filtering happens client-side. Worth a client-layer enhancement when audiobook support lands.

## Tests

- 21 new tests across 3 files (scoring unit, service, API integration)
- Full suite: 183 passing, no regressions

## How to test locally

1. Configure Prowlarr via `PUT /api/v1/integrations/prowlarr` (from 3.1)
2. Add a book via the existing book creation flow
3. `POST /api/v1/book/{book_id}/release-search` — should return scored release list from Prowlarr