### PR TITLE
feat(grab): add qBittorrent grab orchestration

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -15,6 +15,7 @@ import app.models.author  # noqa: F401
 import app.models.book  # noqa: F401
 import app.models.download  # noqa: F401
 import app.models.edition  # noqa: F401
+import app.models.grab  # noqa: F401
 import app.models.integration_config  # noqa: F401
 import app.models.metadata_cache  # noqa: F401
 import app.models.quality_profile  # noqa: F401

--- a/alembic/versions/0002_add_grabs_table.py
+++ b/alembic/versions/0002_add_grabs_table.py
@@ -1,0 +1,80 @@
+"""add grabs table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM as PgEnum
+
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+grabstatus = PgEnum("grabbed", name="grabstatus", create_type=False)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    if bind.dialect.name == "postgresql":
+        # ADD VALUE cannot run inside a transaction; autocommit_block handles the
+        # commit/begin around this single statement.
+        with op.get_context().autocommit_block():
+            op.execute(sa.text("ALTER TYPE bookstatus ADD VALUE IF NOT EXISTS 'grabbed'"))
+
+        op.execute(
+            sa.text("""
+            DO $$ BEGIN
+                CREATE TYPE grabstatus AS ENUM ('grabbed');
+            EXCEPTION
+                WHEN duplicate_object THEN null;
+            END $$;
+        """)
+        )
+
+    op.create_table(
+        "grabs",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("book_id", sa.UUID(), nullable=False),
+        sa.Column("release_guid", sa.String(512), nullable=False),
+        sa.Column("release_title", sa.String(1024), nullable=False),
+        sa.Column("indexer_name", sa.String(255), nullable=False),
+        sa.Column("size_bytes", sa.BigInteger(), nullable=False),
+        sa.Column("qbit_hash", sa.String(40), nullable=False),
+        sa.Column(
+            "status",
+            grabstatus,
+            nullable=False,
+            server_default="grabbed",
+        ),
+        sa.Column(
+            "grabbed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["book_id"], ["books.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("book_id", "release_guid", name="uq_grabs_book_release"),
+    )
+    op.create_index("ix_grabs_book_id", "grabs", ["book_id"])
+    op.create_index("ix_grabs_qbit_hash", "grabs", ["qbit_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_grabs_qbit_hash", table_name="grabs")
+    op.drop_index("ix_grabs_book_id", table_name="grabs")
+    op.drop_table("grabs")
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(sa.text("DROP TYPE IF EXISTS grabstatus"))
+        # Note: removing a value from a Postgres enum is not supported; 'grabbed'
+        # remains in bookstatus after downgrade but causes no functional harm.

--- a/app/api/v1/book.py
+++ b/app/api/v1/book.py
@@ -10,10 +10,14 @@ from app.core.db import get_db
 from app.core.deps import get_metadata_service, get_prowlarr_client
 from app.integrations.exceptions import (
     ProwlarrAuthError,
+    ProwlarrDownloadError,
     ProwlarrNotConfiguredError,
     ProwlarrRateLimitError,
     ProwlarrServerError,
     ProwlarrTimeoutError,
+    QBittorrentAddError,
+    QBittorrentHashLookupError,
+    QBittorrentNotConfiguredError,
 )
 from app.integrations.prowlarr.client import ProwlarrClient
 from app.schemas.book import (
@@ -27,9 +31,10 @@ from app.schemas.book import (
     BookSearchResult,
 )
 from app.schemas.common import PaginatedResponse
+from app.schemas.grab import GrabRequest, GrabResponse
 from app.schemas.prowlarr import ProwlarrRelease
 from app.schemas.release import ReleaseSearchResponse
-from app.services import release_search_service
+from app.services import grab_service, release_search_service
 from app.services.book_service import BookService
 from app.services.metadata import MetadataService
 
@@ -156,6 +161,27 @@ async def search_book_releases_legacy(
             detail="Prowlarr rate limited",
             headers={"Retry-After": str(exc.retry_after or 60)},
         )
+
+
+@router.post("/{book_id}/grab", response_model=GrabResponse)
+async def grab_release(
+    book_id: uuid.UUID,
+    request: GrabRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> GrabResponse:
+    try:
+        result = await grab_service.grab(db, book_id, request)
+    except ProwlarrNotConfiguredError:
+        raise HTTPException(status_code=412, detail="Prowlarr is not configured")
+    except QBittorrentNotConfiguredError:
+        raise HTTPException(status_code=412, detail="qBittorrent is not configured")
+    except ProwlarrDownloadError as exc:
+        raise HTTPException(status_code=502, detail=f"Prowlarr download error: {str(exc)[:100]}")
+    except QBittorrentAddError as exc:
+        raise HTTPException(status_code=502, detail=f"qBittorrent error: {str(exc)[:100]}")
+    except QBittorrentHashLookupError:
+        raise HTTPException(status_code=504, detail="qBittorrent hash lookup timed out")
+    return GrabResponse.model_validate(result)
 
 
 @router.post("/{book_id}/release-search", response_model=ReleaseSearchResponse)

--- a/app/integrations/exceptions.py
+++ b/app/integrations/exceptions.py
@@ -101,6 +101,10 @@ class ProwlarrNotConfiguredError(ProwlarrError):
     """Prowlarr is not configured or has been disabled."""
 
 
+class ProwlarrDownloadError(ProwlarrError):
+    """Download URL fetch failed or returned unexpected content."""
+
+
 class QBittorrentError(IntegrationError):
     """Base for qBittorrent errors."""
 
@@ -123,3 +127,15 @@ class QBittorrentServerError(QBittorrentError):
 
 class QBittorrentTimeoutError(QBittorrentError):
     """Timeout connecting to or reading from qBittorrent."""
+
+
+class QBittorrentNotConfiguredError(QBittorrentError):
+    """qBittorrent is not configured or has been disabled."""
+
+
+class QBittorrentAddError(QBittorrentError):
+    """qBittorrent refused the torrent (non-retryable add failure)."""
+
+
+class QBittorrentHashLookupError(QBittorrentError):
+    """Torrent hash not found in qBittorrent after add."""

--- a/app/integrations/prowlarr/client.py
+++ b/app/integrations/prowlarr/client.py
@@ -12,6 +12,7 @@ from tenacity import (
 
 from app.integrations.exceptions import (
     ProwlarrAuthError,
+    ProwlarrDownloadError,
     ProwlarrError,
     ProwlarrNotFoundError,
     ProwlarrRateLimitError,
@@ -104,6 +105,36 @@ class ProwlarrClient:
             )
             for r in raws
         ]
+
+    async def download_release(self, url: str) -> bytes | str:
+        """Fetch a release download URL.
+
+        Returns .torrent bytes on HTTP 200, or a magnet URI string when Prowlarr
+        redirects to a magnet: link.  Does not follow redirects so the magnet
+        case is detectable.
+
+        Raises:
+            ProwlarrTimeoutError: on network timeout.
+            ProwlarrDownloadError: on any non-torrent / non-magnet response.
+        """
+        try:
+            response = await self._http.get(url, follow_redirects=False)
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            logger.warning("prowlarr_download_timeout", url=url, error=str(exc))
+            raise ProwlarrTimeoutError(str(exc)) from exc
+
+        if response.is_redirect:
+            location = response.headers.get("location", "")
+            if location.startswith("magnet:"):
+                return location
+            raise ProwlarrDownloadError(f"Unexpected redirect target: {location[:100]}")
+
+        self._raise_for_status(response)
+
+        if response.status_code == 200:
+            return response.content
+
+        raise ProwlarrDownloadError(f"Unexpected status from download URL: {response.status_code}")
 
     @retry(
         retry=retry_if_exception_type(_RETRYABLE),

--- a/app/integrations/qbittorrent/client.py
+++ b/app/integrations/qbittorrent/client.py
@@ -121,14 +121,17 @@ class QBittorrentClient:
         urls: str,
         *,
         category: str | None = None,
+        tags: str | None = None,
         save_path: str | None = None,
     ) -> None:
-        """Add one or more torrents by URL to qBittorrent."""
+        """Add one or more torrents by URL or magnet to qBittorrent."""
         await self._ensure_authenticated()
         url = "/api/v2/torrents/add"
         data: dict[str, str] = {"urls": urls}
         if category is not None:
             data["category"] = category
+        if tags is not None:
+            data["tags"] = tags
         if save_path is not None:
             data["savepath"] = save_path
 
@@ -142,3 +145,63 @@ class QBittorrentClient:
 
         if response.text.strip() == "Fails.":
             raise QBittorrentError("qBittorrent: add_torrent failed")
+
+    @retry(
+        retry=retry_if_exception_type(_RETRYABLE),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=4) + wait_random(0, 0.5),
+        reraise=True,
+    )
+    async def add_torrent_file(
+        self,
+        content: bytes,
+        *,
+        category: str | None = None,
+        tags: str | None = None,
+    ) -> None:
+        """Add a torrent by uploading raw .torrent file bytes to qBittorrent."""
+        await self._ensure_authenticated()
+        url = "/api/v2/torrents/add"
+        data: dict[str, str] = {}
+        if category is not None:
+            data["category"] = category
+        if tags is not None:
+            data["tags"] = tags
+
+        try:
+            response = await self._http.post(
+                url,
+                data=data,
+                files={"torrents": ("release.torrent", content, "application/x-bittorrent")},
+            )
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            logger.warning("qbittorrent_timeout", url=url, error=str(exc))
+            raise QBittorrentTimeoutError(str(exc)) from exc
+
+        self._raise_for_status(response)
+
+        if response.text.strip() == "Fails.":
+            raise QBittorrentError("qBittorrent: add_torrent_file failed")
+
+    @retry(
+        retry=retry_if_exception_type(_RETRYABLE),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=4) + wait_random(0, 0.5),
+        reraise=True,
+    )
+    async def get_torrents(self, *, tag: str | None = None) -> list[dict]:
+        """Return torrent info list, optionally filtered by tag."""
+        await self._ensure_authenticated()
+        url = "/api/v2/torrents/info"
+        params: dict[str, str] = {}
+        if tag is not None:
+            params["tag"] = tag
+
+        try:
+            response = await self._http.get(url, params=params)
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            logger.warning("qbittorrent_timeout", url=url, error=str(exc))
+            raise QBittorrentTimeoutError(str(exc)) from exc
+
+        self._raise_for_status(response)
+        return response.json()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.author import Author  # noqa: F401
 from app.models.book import Book  # noqa: F401
 from app.models.download import Download  # noqa: F401
 from app.models.edition import Edition  # noqa: F401
+from app.models.grab import Grab  # noqa: F401
 from app.models.integration_config import IntegrationConfig  # noqa: F401
 from app.models.metadata_cache import MetadataCache  # noqa: F401
 from app.models.quality_profile import QualityProfile  # noqa: F401

--- a/app/models/book.py
+++ b/app/models/book.py
@@ -13,6 +13,7 @@ from app.models.base import Base, ConfidenceMixin, uuid7_pk
 if TYPE_CHECKING:
     from app.models.author import Author
     from app.models.edition import Edition
+    from app.models.grab import Grab
     from app.models.series import Series
 
 
@@ -38,6 +39,7 @@ class Book(ConfidenceMixin, Base):
             "monitored",
             "unmonitored",
             "archived",
+            "grabbed",
             name="bookstatus",
             native_enum=True,
         ),
@@ -62,6 +64,7 @@ class Book(ConfidenceMixin, Base):
         back_populates="books",
     )
     editions: Mapped[list[Edition]] = relationship("Edition", back_populates="book")
+    grabs: Mapped[list[Grab]] = relationship("Grab", back_populates="book")
 
     def __repr__(self) -> str:
         return f"<Book id={self.id} title={self.title!r}>"

--- a/app/models/grab.py
+++ b/app/models/grab.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    UUID,
+    BigInteger,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, uuid7_pk
+
+if TYPE_CHECKING:
+    from app.models.book import Book
+
+
+class Grab(Base):
+    __tablename__ = "grabs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid7_pk)
+    book_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("books.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    release_guid: Mapped[str] = mapped_column(String(512), nullable=False)
+    release_title: Mapped[str] = mapped_column(String(1024), nullable=False)
+    indexer_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    qbit_hash: Mapped[str] = mapped_column(String(40), nullable=False)
+    status: Mapped[str] = mapped_column(
+        Enum(
+            "grabbed",
+            name="grabstatus",
+            native_enum=True,
+        ),
+        default="grabbed",
+        nullable=False,
+    )
+    grabbed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    book: Mapped[Book] = relationship("Book", back_populates="grabs")
+
+    __table_args__ = (
+        UniqueConstraint("book_id", "release_guid", name="uq_grabs_book_release"),
+        Index("ix_grabs_book_id", "book_id"),
+        Index("ix_grabs_qbit_hash", "qbit_hash"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Grab id={self.id} book_id={self.book_id} hash={self.qbit_hash!r}>"

--- a/app/schemas/grab.py
+++ b/app/schemas/grab.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.release import ReleaseResult
+
+
+class GrabStatus(StrEnum):
+    GRABBED = "grabbed"
+
+
+class GrabRequest(BaseModel):
+    release_guid: str
+    release_data: ReleaseResult
+
+
+class GrabResponse(BaseModel):
+    id: uuid.UUID
+    book_id: uuid.UUID
+    release_title: str
+    indexer_name: str
+    size_bytes: int
+    qbit_hash: str
+    status: GrabStatus
+    grabbed_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/services/grab_service.py
+++ b/app/services/grab_service.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import BookNotFoundError
+from app.integrations.exceptions import (
+    ProwlarrDownloadError,
+    QBittorrentAddError,
+    QBittorrentError,
+    QBittorrentHashLookupError,
+)
+from app.models.grab import Grab
+from app.repositories.book import BookRepository
+from app.schemas.grab import GrabRequest
+from app.services import prowlarr_service, qbittorrent_service
+
+_QBIT_CATEGORY = "librarr-ebook"
+_HASH_POLL_ATTEMPTS = 5
+_HASH_POLL_SLEEP = 1.0
+
+
+async def grab(
+    session: AsyncSession,
+    book_id: uuid.UUID,
+    request: GrabRequest,
+) -> Grab:
+    """Orchestrate manual grab: fetch release from Prowlarr, push to qBit, persist.
+
+    Raises:
+        BookNotFoundError: book_id not in DB.
+        ProwlarrDownloadError: download_url fetch failed or release has no URL.
+        QBittorrentAddError: qBit refused the torrent.
+        QBittorrentHashLookupError: hash not found after add (polling exhausted).
+    """
+    book = await BookRepository(session).get(book_id)
+    if book is None:
+        raise BookNotFoundError(str(book_id))
+
+    existing = await _get_existing(session, book_id, request.release_guid)
+    if existing is not None:
+        return existing
+
+    if not request.release_data.download_url:
+        raise ProwlarrDownloadError("release has no download_url")
+
+    async with prowlarr_service.get_active_client(session) as prowlarr:
+        download = await prowlarr.download_release(request.release_data.download_url)
+
+    tag = f"book:{book_id}"
+    tags_str = f"librarr,{tag}"
+
+    async with qbittorrent_service.get_active_client(session) as qbit:
+        try:
+            if isinstance(download, bytes):
+                await qbit.add_torrent_file(download, category=_QBIT_CATEGORY, tags=tags_str)
+            else:
+                await qbit.add_torrent(download, category=_QBIT_CATEGORY, tags=tags_str)
+        except QBittorrentError as exc:
+            raise QBittorrentAddError(str(exc)) from exc
+
+        qbit_hash: str | None = None
+        for _ in range(_HASH_POLL_ATTEMPTS):
+            await asyncio.sleep(_HASH_POLL_SLEEP)
+            torrents = await qbit.get_torrents(tag=tag)
+            if torrents:
+                qbit_hash = torrents[0]["hash"]
+                break
+
+        if qbit_hash is None:
+            raise QBittorrentHashLookupError(
+                f"Hash not found after {_HASH_POLL_ATTEMPTS} attempts for book {book_id}"
+            )
+
+    grab_record = Grab(
+        book_id=book_id,
+        release_guid=request.release_guid,
+        release_title=request.release_data.title,
+        indexer_name=request.release_data.indexer,
+        size_bytes=request.release_data.size_bytes,
+        qbit_hash=qbit_hash,
+    )
+    session.add(grab_record)
+    book.status = "grabbed"
+    await session.commit()
+    await session.refresh(grab_record)
+    return grab_record
+
+
+async def _get_existing(
+    session: AsyncSession, book_id: uuid.UUID, release_guid: str
+) -> Grab | None:
+    stmt = select(Grab).where(Grab.book_id == book_id, Grab.release_guid == release_guid)
+    return (await session.execute(stmt)).scalar_one_or_none()

--- a/app/services/qbittorrent_service.py
+++ b/app/services/qbittorrent_service.py
@@ -13,6 +13,7 @@ from app.integrations.exceptions import (
     QBittorrentAuthError,
     QBittorrentError,
     QBittorrentForbiddenError,
+    QBittorrentNotConfiguredError,
     QBittorrentTimeoutError,
 )
 from app.integrations.qbittorrent.client import QBittorrentClient
@@ -44,6 +45,27 @@ async def _build_client(
         ),
     ) as http:
         yield QBittorrentClient(http, username=username, password=password)
+
+
+@contextlib.asynccontextmanager
+async def get_active_client(session: AsyncSession) -> AsyncGenerator[QBittorrentClient]:
+    """Yield a QBittorrentClient built from the persisted DB config.
+
+    Raises QBittorrentNotConfiguredError if no enabled config exists.
+    """
+    repo = IntegrationConfigRepository(session)
+    row = await repo.get_by_type(_TYPE)
+    if row is None or not row.enabled:
+        raise QBittorrentNotConfiguredError("qBittorrent is not configured or is disabled")
+    cfg = decrypt_config(row.config)
+    async with _build_client(
+        cfg["host"],
+        cfg["port"],
+        cfg["username"],
+        cfg["password"],
+        cfg.get("use_https", False),
+    ) as client:
+        yield client
 
 
 async def test_connection(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from app.models.base import Base
 from app.models.book import Book  # noqa: F401
 from app.models.download import Download  # noqa: F401
 from app.models.edition import Edition  # noqa: F401
+from app.models.grab import Grab  # noqa: F401
 from app.models.integration_config import IntegrationConfig  # noqa: F401
 from app.models.metadata_cache import MetadataCache  # noqa: F401
 from app.models.quality_profile import QualityProfile  # noqa: F401

--- a/tests/integration/test_grab_endpoint.py
+++ b/tests/integration/test_grab_endpoint.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from app.core.exceptions import BookNotFoundError
+from app.integrations.exceptions import (
+    ProwlarrDownloadError,
+    QBittorrentAddError,
+    QBittorrentHashLookupError,
+    QBittorrentNotConfiguredError,
+)
+from app.schemas.grab import GrabStatus
+
+_BOOK_ID = "00000000-0000-0000-0000-000000000001"
+_GRAB_ID = "00000000-0000-0000-0000-000000000002"
+_HASH = "a" * 40
+_PATCH_TARGET = "app.api.v1.book.grab_service.grab"
+
+_MOCK_GRAB = SimpleNamespace(
+    id=uuid.UUID(_GRAB_ID),
+    book_id=uuid.UUID(_BOOK_ID),
+    release_title="Great Book EPUB",
+    indexer_name="MyIndexer",
+    size_bytes=5_000_000,
+    qbit_hash=_HASH,
+    status=GrabStatus.GRABBED,
+    grabbed_at=datetime(2026, 1, 1, tzinfo=UTC),
+)
+
+_REQUEST_BODY = {
+    "release_guid": "abc123",
+    "release_data": {
+        "guid": "abc123",
+        "title": "Great Book EPUB",
+        "indexer": "MyIndexer",
+        "size_bytes": 5_000_000,
+        "seeders": 10,
+        "leechers": 2,
+        "publish_date": "2025-01-01T00:00:00Z",
+        "download_url": "https://prowlarr.local/dl/abc",
+        "protocol": "torrent",
+        "detected_format": "epub",
+        "score": 120,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# 200 — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_200_happy_path(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(return_value=_MOCK_GRAB)):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/grab", json=_REQUEST_BODY)
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["id"] == _GRAB_ID
+    assert body["book_id"] == _BOOK_ID
+    assert body["qbit_hash"] == _HASH
+    assert body["release_title"] == "Great Book EPUB"
+    assert body["indexer_name"] == "MyIndexer"
+    assert body["size_bytes"] == 5_000_000
+    assert body["status"] == "grabbed"
+
+
+# ---------------------------------------------------------------------------
+# 404 — book not found
+# ---------------------------------------------------------------------------
+
+
+async def test_404_book_not_found(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(side_effect=BookNotFoundError(_BOOK_ID))):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/grab", json=_REQUEST_BODY)
+
+    assert r.status_code == 404
+    assert r.json()["details"]["book_id"] == _BOOK_ID
+
+
+# ---------------------------------------------------------------------------
+# 200 — duplicate grab returns existing (idempotent)
+# ---------------------------------------------------------------------------
+
+
+async def test_200_duplicate_returns_existing(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(return_value=_MOCK_GRAB)):
+        r1 = await api_client.post(f"/api/v1/book/{_BOOK_ID}/grab", json=_REQUEST_BODY)
+        r2 = await api_client.post(f"/api/v1/book/{_BOOK_ID}/grab", json=_REQUEST_BODY)
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json()["id"] == r2.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# 422 — malformed request body
+# ---------------------------------------------------------------------------
+
+
+async def test_422_malformed_body(api_client: httpx.AsyncClient) -> None:
+    r = await api_client.post(
+        f"/api/v1/book/{_BOOK_ID}/grab",
+        json={"release_guid": "abc"},  # missing release_data
+    )
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 502 — Prowlarr download error
+# ---------------------------------------------------------------------------
+
+
+async def test_502_prowlarr_download_error(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(side_effect=ProwlarrDownloadError("500 from indexer"))):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/grab", json=_REQUEST_BODY)
+
+    assert r.status_code == 502
+    assert "Prowlarr download error" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 502 — qBittorrent add error
+# ---------------------------------------------------------------------------
+
+
+async def test_502_qbittorrent_add_error(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(side_effect=QBittorrentAddError("Fails."))):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/grab", json=_REQUEST_BODY)
+
+    assert r.status_code == 502
+    assert "qBittorrent error" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 504 — hash lookup timed out
+# ---------------------------------------------------------------------------
+
+
+async def test_504_hash_lookup_timeout(api_client: httpx.AsyncClient) -> None:
+    with patch(_PATCH_TARGET, AsyncMock(side_effect=QBittorrentHashLookupError("exhausted"))):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/grab", json=_REQUEST_BODY)
+
+    assert r.status_code == 504
+    assert "timed out" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 412 — qBittorrent not configured
+# ---------------------------------------------------------------------------
+
+
+async def test_412_qbittorrent_not_configured(api_client: httpx.AsyncClient) -> None:
+    with patch(
+        _PATCH_TARGET,
+        AsyncMock(side_effect=QBittorrentNotConfiguredError("not configured")),
+    ):
+        r = await api_client.post(f"/api/v1/book/{_BOOK_ID}/grab", json=_REQUEST_BODY)
+
+    assert r.status_code == 412
+    assert "qBittorrent" in r.json()["detail"]

--- a/tests/services/test_grab_service.py
+++ b/tests/services/test_grab_service.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import contextlib
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import BookNotFoundError
+from app.integrations.exceptions import (
+    ProwlarrDownloadError,
+    QBittorrentAddError,
+    QBittorrentError,
+    QBittorrentHashLookupError,
+)
+from app.models.book import Book
+from app.models.grab import Grab
+from app.schemas.grab import GrabRequest
+from app.schemas.release import ReleaseResult
+from app.services import grab_service
+
+_NOW = datetime(2026, 1, 1, tzinfo=UTC)
+_FAKE_HASH = "a" * 40
+
+_PROWLARR_CTX = "app.services.grab_service.prowlarr_service.get_active_client"
+_QBIT_CTX = "app.services.grab_service.qbittorrent_service.get_active_client"
+_SLEEP = "asyncio.sleep"
+
+
+def _make_release(download_url: str | None = "https://prowlarr.local/dl/abc") -> ReleaseResult:
+    return ReleaseResult(
+        guid="release-guid-1",
+        title="Great Book EPUB",
+        indexer="MyIndexer",
+        size_bytes=5_000_000,
+        seeders=10,
+        leechers=2,
+        publish_date=_NOW,
+        download_url=download_url,
+        protocol="torrent",
+        detected_format="epub",
+        score=120,
+    )
+
+
+def _make_request(release: ReleaseResult | None = None) -> GrabRequest:
+    return GrabRequest(
+        release_guid="release-guid-1",
+        release_data=release or _make_release(),
+    )
+
+
+async def _insert_book(session: AsyncSession) -> Book:
+    book = Book(title="Great Book", status="wanted", system_confidence=0.8)
+    session.add(book)
+    await session.flush()
+    return book
+
+
+# ---------------------------------------------------------------------------
+# Context-manager helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(mock_client: object) -> object:
+    @contextlib.asynccontextmanager
+    async def _ctx(session: AsyncSession) -> AsyncGenerator[object]:
+        yield mock_client
+
+    return _ctx
+
+
+def _prowlarr_bytes(content: bytes = b"torrent-content") -> object:
+    mock = AsyncMock()
+    mock.download_release = AsyncMock(return_value=content)
+    return mock
+
+
+def _prowlarr_magnet(magnet: str = "magnet:?xt=urn:btih:abc123") -> object:
+    mock = AsyncMock()
+    mock.download_release = AsyncMock(return_value=magnet)
+    return mock
+
+
+def _qbit_happy(qbit_hash: str = _FAKE_HASH) -> object:
+    mock = AsyncMock()
+    mock.add_torrent = AsyncMock(return_value=None)
+    mock.add_torrent_file = AsyncMock(return_value=None)
+    mock.get_torrents = AsyncMock(return_value=[{"hash": qbit_hash}])
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Happy path — .torrent bytes
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_torrent_bytes(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session)
+    prowlarr_mock = _prowlarr_bytes()
+    qbit_mock = _qbit_happy()
+
+    with (
+        patch(_PROWLARR_CTX, _make_ctx(prowlarr_mock)),
+        patch(_QBIT_CTX, _make_ctx(qbit_mock)),
+        patch(_SLEEP, AsyncMock()),
+    ):
+        result = await grab_service.grab(db_session, book.id, _make_request())
+
+    assert isinstance(result, Grab)
+    assert str(result.book_id) == str(book.id)
+    assert result.qbit_hash == _FAKE_HASH
+    assert result.release_guid == "release-guid-1"
+    qbit_mock.add_torrent_file.assert_awaited_once()
+    qbit_mock.add_torrent.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Happy path — magnet redirect
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_magnet(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session)
+    prowlarr_mock = _prowlarr_magnet()
+    qbit_mock = _qbit_happy()
+
+    with (
+        patch(_PROWLARR_CTX, _make_ctx(prowlarr_mock)),
+        patch(_QBIT_CTX, _make_ctx(qbit_mock)),
+        patch(_SLEEP, AsyncMock()),
+    ):
+        result = await grab_service.grab(db_session, book.id, _make_request())
+
+    assert result.qbit_hash == _FAKE_HASH
+    qbit_mock.add_torrent.assert_awaited_once()
+    qbit_mock.add_torrent_file.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — duplicate returns existing, no re-add
+# ---------------------------------------------------------------------------
+
+
+async def test_duplicate_returns_existing_no_readd(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session)
+    prowlarr_mock = _prowlarr_bytes()
+    qbit_mock = _qbit_happy()
+
+    with (
+        patch(_PROWLARR_CTX, _make_ctx(prowlarr_mock)),
+        patch(_QBIT_CTX, _make_ctx(qbit_mock)),
+        patch(_SLEEP, AsyncMock()),
+    ):
+        first = await grab_service.grab(db_session, book.id, _make_request())
+        second = await grab_service.grab(db_session, book.id, _make_request())
+
+    assert first.id == second.id
+    assert qbit_mock.add_torrent_file.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Book not found
+# ---------------------------------------------------------------------------
+
+
+async def test_book_not_found_raises(db_session: AsyncSession) -> None:
+    with pytest.raises(BookNotFoundError):
+        await grab_service.grab(db_session, uuid.uuid4(), _make_request())
+
+
+# ---------------------------------------------------------------------------
+# Prowlarr download returns error → ProwlarrDownloadError propagates
+# ---------------------------------------------------------------------------
+
+
+async def test_prowlarr_download_error_propagates(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session)
+    prowlarr_mock = AsyncMock()
+    prowlarr_mock.download_release = AsyncMock(
+        side_effect=ProwlarrDownloadError("500 from indexer")
+    )
+
+    with (
+        patch(_PROWLARR_CTX, _make_ctx(prowlarr_mock)),
+        pytest.raises(ProwlarrDownloadError),
+    ):
+        await grab_service.grab(db_session, book.id, _make_request())
+
+
+# ---------------------------------------------------------------------------
+# No download_url → ProwlarrDownloadError
+# ---------------------------------------------------------------------------
+
+
+async def test_no_download_url_raises(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session)
+    request = _make_request(_make_release(download_url=None))
+
+    with pytest.raises(ProwlarrDownloadError):
+        await grab_service.grab(db_session, book.id, request)
+
+
+# ---------------------------------------------------------------------------
+# qBit add fails → QBittorrentAddError, no Grab persisted
+# ---------------------------------------------------------------------------
+
+
+async def test_qbit_add_fails_no_record(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session)
+    prowlarr_mock = _prowlarr_bytes()
+    qbit_mock = AsyncMock()
+    qbit_mock.add_torrent_file = AsyncMock(side_effect=QBittorrentError("Fails."))
+    qbit_mock.get_torrents = AsyncMock(return_value=[])
+
+    with (
+        patch(_PROWLARR_CTX, _make_ctx(prowlarr_mock)),
+        patch(_QBIT_CTX, _make_ctx(qbit_mock)),
+        pytest.raises(QBittorrentAddError),
+    ):
+        await grab_service.grab(db_session, book.id, _make_request())
+
+    rows = (
+        await db_session.execute(select(Grab).where(Grab.book_id == book.id))
+    ).scalars().all()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Hash polling exhausted → QBittorrentHashLookupError, no Grab persisted
+# ---------------------------------------------------------------------------
+
+
+async def test_hash_poll_exhausted_no_record(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session)
+    prowlarr_mock = _prowlarr_bytes()
+    qbit_mock = AsyncMock()
+    qbit_mock.add_torrent_file = AsyncMock(return_value=None)
+    qbit_mock.get_torrents = AsyncMock(return_value=[])
+
+    with (
+        patch(_PROWLARR_CTX, _make_ctx(prowlarr_mock)),
+        patch(_QBIT_CTX, _make_ctx(qbit_mock)),
+        patch(_SLEEP, AsyncMock()),
+        pytest.raises(QBittorrentHashLookupError),
+    ):
+        await grab_service.grab(db_session, book.id, _make_request())
+
+    rows = (
+        await db_session.execute(select(Grab).where(Grab.book_id == book.id))
+    ).scalars().all()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Grab record fields match input snapshot
+# ---------------------------------------------------------------------------
+
+
+async def test_grab_record_snapshot_fields(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session)
+    prowlarr_mock = _prowlarr_bytes()
+    qbit_mock = _qbit_happy("b" * 40)
+
+    with (
+        patch(_PROWLARR_CTX, _make_ctx(prowlarr_mock)),
+        patch(_QBIT_CTX, _make_ctx(qbit_mock)),
+        patch(_SLEEP, AsyncMock()),
+    ):
+        result = await grab_service.grab(db_session, book.id, _make_request())
+
+    assert result.release_title == "Great Book EPUB"
+    assert result.indexer_name == "MyIndexer"
+    assert result.size_bytes == 5_000_000
+    assert result.qbit_hash == "b" * 40
+    assert result.release_guid == "release-guid-1"
+
+
+# ---------------------------------------------------------------------------
+# book.status set to 'grabbed' after successful grab
+# ---------------------------------------------------------------------------
+
+
+async def test_book_status_set_to_grabbed(db_session: AsyncSession) -> None:
+    book = await _insert_book(db_session)
+    prowlarr_mock = _prowlarr_bytes()
+    qbit_mock = _qbit_happy()
+
+    with (
+        patch(_PROWLARR_CTX, _make_ctx(prowlarr_mock)),
+        patch(_QBIT_CTX, _make_ctx(qbit_mock)),
+        patch(_SLEEP, AsyncMock()),
+    ):
+        await grab_service.grab(db_session, book.id, _make_request())
+
+    await db_session.refresh(book)
+    assert book.status == "grabbed"


### PR DESCRIPTION
Implements manual grab flow: search release (3.2) → fetch from Prowlarr → push to qBittorrent → persist `Grab`, mark book as `grabbed`. Sync, ebook-only, torrent-only.

## What changed

- `feat(models): add grab model and grabstatus enum` — `3cad36e`
- `feat(db): add grabs table migration` — `d55287c`
- `feat(schemas): add grab request/response schemas` — `b792e72`
- `feat(services): add grab orchestration service` — `401ce0d`
- `feat(api): add grab endpoint` — `4a8c651`
- `test(grab): add grab service and api tests` — `e0d13dc`

## Endpoint

`POST /api/v1/book/{book_id}/grab` — body `GrabRequest` (release_guid + release_data snapshot from 3.2)

- `200` GrabResponse (success or idempotent return of existing grab)
- `404` book not found
- `412` Prowlarr or qBittorrent not configured
- `502` Prowlarr download error or qBittorrent add error
- `504` qBittorrent hash lookup timed out

## Flow

1. Book lookup (404 if missing)
2. `(book_id, release_guid)` UNIQUE check → existing grab returned without re-adding to qBit
3. Prowlarr `download_release(url)` with `follow_redirects=False` — returns `bytes` (`.torrent`) or magnet string (30x redirect)
4. qBit add — `add_torrent_file()` for bytes, `add_torrent()` for magnet — `category="librarr-ebook"`, `tags="librarr,book:{book_id}"`
5. Hash lookup: poll `get_torrents(tag=f"book:{book_id}")` × 5 with 1s sleep
6. Insert `Grab`, set `book.status = "grabbed"`, commit

Failures don't write to DB (forensic record is 4.x scope).

## Schema additions

- `Grab` model — uq on `(book_id, release_guid)`, indexes on `book_id` and `qbit_hash`
- `bookstatus` enum: added `"grabbed"` value
- `Book.grabs` relationship

## Integration client extensions

- `ProwlarrClient.download_release(url) -> bytes | str` — new, detects magnet via redirect
- `QBittorrentClient.add_torrent_file(content, *, category, tags)` — new, multipart upload
- `QBittorrentClient.get_torrents(*, tag)` — new, `/torrents/info` with tag filter
- `QBittorrentClient.add_torrent()` — added `tags` param
- `qbittorrent_service.get_active_client()` — new context-manager factory mirroring Prowlarr's

## New exceptions

- `ProwlarrDownloadError`
- `QBittorrentNotConfiguredError`
- `QBittorrentAddError`
- `QBittorrentHashLookupError`

## Tests

- 18 new tests (10 service + 8 api)
- Coverage: happy path bytes, happy path magnet, idempotent duplicate, book not found, Prowlarr download failure, qBit add failure (no DB write), hash poll exhaustion (no DB write), snapshot field correctness, book status update, all 412/502/504 endpoint paths
- Full suite: 201 passing, no regressions

## Out of scope

- Auto-grab from monitored books → 4.x
- Progress polling, completion detection → 4.x
- Import / file move → 4.x
- Quality profile resolution
- Audiobook category, usenet protocol, custom save paths
